### PR TITLE
Bump Valkey to 2 GB to stop parser cache thrashing

### DIFF
--- a/mediawiki/valkey-config.yaml
+++ b/mediawiki/valkey-config.yaml
@@ -4,5 +4,5 @@ metadata:
     name: valkey-config
 data:
     config: |
-        maxmemory 500mb
+        maxmemory 2gb
         maxmemory-policy allkeys-lru

--- a/mediawiki/valkey.yaml
+++ b/mediawiki/valkey.yaml
@@ -50,10 +50,10 @@ spec:
                         name: valkey
                   resources:
                       requests:
-                          memory: '128Mi'
+                          memory: '2Gi'
                           cpu: '100m'
                       limits:
-                          memory: '3Gi'
+                          memory: '4Gi'
                           cpu: '1.5'
                   volumeMounts:
                       - name: valkey-pv


### PR DESCRIPTION
Cache was sitting at 99.9% of the 500 MB cap with 111K cumulative evictions; only ~3.5K parser cache entries fit at any time, so most parsed pages were evicted before the next reader arrived (cache hit rate of ~88% overall, but parser cache effectively useless on the long tail).

Coordinate the three knobs:
  - maxmemory:        500mb -> 2gb     (Valkey self-cap)
  - requests.memory:  128Mi -> 2Gi     (honest scheduler reservation)
  - limits.memory:    3Gi   -> 4Gi     (~50% fork headroom over maxmemory)

Node has 7.4 Gi of unallocated request capacity, so this fits comfortably with room for further growth if needed.