### PR TITLE
Pool nginx -> php-fpm connections via upstream keepalive

### DIFF
--- a/mediawiki/nginx-config.yaml
+++ b/mediawiki/nginx-config.yaml
@@ -6,6 +6,11 @@ data:
     config: |
         # error_log /var/log/nginx/debug.log debug;
 
+        upstream php_fpm {
+          server php-service.default.svc.cluster.local:9000;
+          keepalive 32;
+        }
+
         server {
           listen 0.0.0.0:80;
           server_name starcitizen.tools;
@@ -48,7 +53,8 @@ data:
             try_files $uri $uri/ /rest.php?$args;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME	$document_root/rest.php;
-            fastcgi_pass php-service.default.svc.cluster.local:9000;
+            fastcgi_pass php_fpm;
+            fastcgi_keep_conn on;
           }
           
           # Location for the wiki's root
@@ -58,7 +64,8 @@ data:
             location ~ \.php$ {
               try_files $uri $uri/ =404; # Don't let php execute non-existent php files
               include fastcgi_params;
-              fastcgi_pass php-service.default.svc.cluster.local:9000;
+              fastcgi_pass php_fpm;
+              fastcgi_keep_conn on;
               fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             }
           }
@@ -123,7 +130,8 @@ data:
             include fastcgi_params;
             # article path should always be passed to index.php
             fastcgi_param SCRIPT_FILENAME	$document_root/index.php;
-            fastcgi_pass php-service.default.svc.cluster.local:9000;
+            fastcgi_pass php_fpm;
+            fastcgi_keep_conn on;
           }
 
           # Thumbnail 404 handler, only called by try_files when a thumbnail does not exist
@@ -135,6 +143,7 @@ data:
             # Run the thumb.php script
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME	$document_root/thumb.php;
-            fastcgi_pass php-service.default.svc.cluster.local:9000;
+            fastcgi_pass php_fpm;
+            fastcgi_keep_conn on;
           }
         }


### PR DESCRIPTION
## Summary
- Defines a named `upstream php_fpm` with `keepalive 32` so nginx pools persistent TCP connections to php-fpm instead of opening a fresh one per request.
- Adds `fastcgi_keep_conn on;` to each `location` that does `fastcgi_pass`.

## Why
nginx error logs were showing repeated `(110: Connection timed out) while connecting to upstream` against `fastcgi://php-service…:9000`, with corresponding 504s and a flood of client-abort 499s. The proximate cause was per-request TCP churn to php-fpm: under burst load, half-open connections piled up in the kernel listen backlog faster than FPM's 30 workers could `accept()`, and new `connect()` calls timed out. Pooling eliminates this failure mode — nginx reuses up to 32 persistent connections per worker, so the FPM listen socket sees a near-constant connection count regardless of request rate.

This does **not** add FPM capacity; if all 30 workers are busy the queue simply shifts from "kernel SYN backlog" to "FPM listen queue" — but that is a graceful saturation handled by `fastcgi_read_timeout` (default 60s) rather than the silent connect-timeout failures we see today.

## Test plan
- [ ] `kubectl apply -f mediawiki/nginx-config.yaml`
- [ ] `kubectl rollout restart deployment/nginx`
- [ ] `kubectl rollout status deployment/nginx --timeout=60s`
- [ ] Loki: `{app="nginx"} |~ "while connecting to upstream"` should go silent within minutes.
- [ ] Loki: `{app="nginx"} |~ "worker_connections are not enough"` — watch for whether this persists or fades. If it persists under load, a follow-up PR to raise `worker_connections` is queued.
- [ ] Spot-check site loads in browser (article view, search, edit submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)