### PR TITLE
Auto-restart workloads when their ConfigMaps change

### DIFF
--- a/.github/workflows/kubernetes-deploy.yml
+++ b/.github/workflows/kubernetes-deploy.yml
@@ -87,6 +87,61 @@ jobs:
             shared
           strategy: basic
           action: deploy
+
+      - name: Restart workloads with changed ConfigMaps
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Kubernetes does not natively roll a workload when its mounted
+          # ConfigMap data changes -- the file on disk updates within ~60s
+          # but the process inside the container has no idea. Detect changed
+          # ConfigMap files in this push and trigger a rolling restart of
+          # the consuming workloads.
+
+          if [[ -z "${BEFORE_SHA}" || "${BEFORE_SHA}" == "0000000000000000000000000000000000000000" ]]; then
+            echo "No previous SHA (branch-create or initial push); skipping auto-restart."
+            exit 0
+          fi
+
+          if ! changed=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BEFORE_SHA}...${AFTER_SHA}" --jq '.files[].filename' 2>&1); then
+            echo "Failed to enumerate changed files: ${changed}"
+            echo "Skipping auto-restart."
+            exit 0
+          fi
+
+          echo "Changed files in this push:"
+          printf '  %s\n' ${changed:-"(none)"}
+
+          # Map: tracked ConfigMap file -> workload that needs a restart.
+          declare -A CM_TO_WORKLOAD=(
+            ["mediawiki/nginx-config.yaml"]="deployment/nginx"
+            ["mediawiki/mariadb-config.yaml"]="statefulset/mariadb-sts"
+            ["mediawiki/valkey-config.yaml"]="statefulset/valkey-sts"
+          )
+
+          declare -A to_restart
+          while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            w="${CM_TO_WORKLOAD[$f]:-}"
+            [[ -z "$w" ]] && continue
+            to_restart["$w"]=1
+          done <<< "$changed"
+
+          if [[ ${#to_restart[@]} -eq 0 ]]; then
+            echo "No tracked ConfigMap changes; nothing to restart."
+            exit 0
+          fi
+
+          for w in "${!to_restart[@]}"; do
+            echo "::group::Rolling restart $w"
+            kubectl rollout restart "$w"
+            kubectl rollout status "$w" --timeout=180s
+            echo "::endgroup::"
+          done
   debug:
     runs-on: ubuntu-latest
     needs: docker

--- a/mediawiki/nginx-config.yaml
+++ b/mediawiki/nginx-config.yaml
@@ -4,6 +4,8 @@ metadata:
     name: nginx-config
 data:
     config: |
+        # Managed via sct-k8-config. deployment/nginx is auto-restarted by
+        # .github/workflows/kubernetes-deploy.yml when this file changes.
         # error_log /var/log/nginx/debug.log debug;
 
         upstream php_fpm {


### PR DESCRIPTION
## Summary
- New post-deploy step in `kubernetes-deploy.yml` that detects changed ConfigMap files via the GitHub compare API and runs `kubectl rollout restart` for the affected workloads.
- Tracked mappings:
  - `mediawiki/nginx-config.yaml` → `deployment/nginx`
  - `mediawiki/mariadb-config.yaml` → `statefulset/mariadb-sts`
  - `mediawiki/valkey-config.yaml` → `statefulset/valkey-sts`
- Adds a comment to `mediawiki/nginx-config.yaml` documenting the auto-restart behavior. **This also makes nginx-config.yaml part of this PR's diff, so on merge the new logic will rollout-restart nginx and finally activate the keepalive config from #10** (which is currently sitting on disk but unused because the running nginx process never reloaded).

## Why
Kubernetes does **not** roll a workload when a mounted ConfigMap changes. The file in the pod's volume mount updates within ~60s (non-`subPath` mounts only), but nothing tells the process inside the container to re-read it. PR #10 shipped successfully — the new `site.conf` is on disk in the nginx pod — yet the nginx process is still serving the old config because it never got SIGHUP'd or restarted.

This is a recurring footgun that will bite again the next time `mariadb-config.yaml` or `valkey-config.yaml` changes. The post-deploy step makes it impossible to forget.

## How it works
1. Pull the list of files changed between `github.event.before` and `github.event.after` via `gh api repos/.../compare/...`. Uses the GitHub API instead of `git diff` to avoid `fetch-depth` issues with the default shallow checkout.
2. Look each changed file up in a hard-coded `ConfigMap file → workload` map.
3. Deduplicate, then `kubectl rollout restart` each affected workload and wait for the rollout to complete.

Skipped cleanly on branch-create pushes (when `before` is the zero SHA) and on compare-API failures (logs and exits 0 rather than failing the whole deploy).

## Test plan
- [ ] CI runs successfully on merge.
- [ ] Workflow logs show the "Restart workloads with changed ConfigMaps" step detecting `mediawiki/nginx-config.yaml` and running `kubectl rollout restart deployment/nginx`.
- [ ] `kube_pod_start_time{pod=~"nginx-.*"}` resets to ~0 shortly after the merge — i.e. a new nginx pod actually started.
- [ ] Loki: `{app="nginx"} |~ "while connecting to upstream"` goes silent (the actual goal of #10).
- [ ] Subsequent deploys that touch *only* `mediawiki/nginx.yaml` (Deployment) do **not** redundantly trigger this step — workload-level changes are already rolled by `Azure/k8s-deploy`.

## Future extensions
- Add `plausible/clickhouse-config.yaml` → `statefulset/clickhouse` (or whatever its workload kind is) to the map.
- Add a `workflow_dispatch` trigger with a `force_restart_all` input for ad-hoc manual restarts when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)