### PR TITLE
Fix unbound-variable error in ConfigMap restart step

### DIFF
--- a/.github/workflows/kubernetes-deploy.yml
+++ b/.github/workflows/kubernetes-deploy.yml
@@ -94,7 +94,11 @@ jobs:
           AFTER_SHA: ${{ github.event.after }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          # NOTE: deliberately not using `set -u` -- bash errors on
+          # ${#assoc_array[@]} when the associative array has never had
+          # an element assigned, which breaks the "nothing to restart"
+          # path of this script. -e and pipefail are enough for safety.
+          set -eo pipefail
 
           # Kubernetes does not natively roll a workload when its mounted
           # ConfigMap data changes -- the file on disk updates within ~60s


### PR DESCRIPTION
## Summary
Drop `-u` from the strict-mode flags in the post-deploy ConfigMap-restart step added in #11. Keep `-e` and `pipefail`.

## Why
Today's "Bump Docker images" CI run (https://github.com/StarCitizenTools/sct-k8-config/actions/runs/25979472810) marked the docker job as failed even though the actual `kubectl apply` and rollouts succeeded — the new php-mediawiki image with the PoolCounter config came up cleanly. The failure was in the auto-restart step, with this error:

```
line 38: to_restart: unbound variable
##[error]Process completed with exit code 1.
```

Reproduced locally: under `set -u`, bash treats `${#to_restart[@]}` on a `declare -A`-but-never-populated associative array as referencing an unset variable and aborts. The "nothing to restart" branch is exactly the case where this happens — when a push doesn't touch any tracked ConfigMap file. Today's push only touched `mediawiki/php-mediawiki.yaml` and similar workload manifests, so the map stayed empty and the script crashed before it could log its "nothing to restart" message.

Three ways to fix this:
1. **Drop `-u`** (this PR). Simplest. -e and pipefail still catch real errors. The script already defaults every variable expansion with `${var:-}`.
2. Initialize `to_restart` with a placeholder element, then `unset` it before iterating. Ugly.
3. Use `${to_restart[@]+x}` existence test. More portable but visually obscure.

Going with 1.

## Test plan
- [x] Local repro confirms the error with `-u` and confirms the fix without `-u`.
- [ ] Next CI run on `smw` reports success on the "Restart workloads with changed ConfigMaps" step, with output "No tracked ConfigMap changes; nothing to restart." (assuming nothing in `mediawiki/{nginx,mariadb,valkey}-config.yaml` changes).
- [ ] A future PR that does touch one of those ConfigMaps still triggers the rollout-restart logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)