### PR TITLE
Raise Valkey maxmemory from 2 GB to 3 GB

### DIFF
--- a/mediawiki/valkey-config.yaml
+++ b/mediawiki/valkey-config.yaml
@@ -4,5 +4,5 @@ metadata:
     name: valkey-config
 data:
     config: |
-        maxmemory 2gb
+        maxmemory 3gb
         maxmemory-policy allkeys-lru


### PR DESCRIPTION
## Summary
Bump `maxmemory` from `2gb` → `3gb` in `mediawiki/valkey-config.yaml`. No K8s resource changes.

## Why
Valkey is chronically undersized. From the Valkey Diagnostics workflow:

| Counter | Value |
|---|---|
| `evicted_keys` (LRU-forced) | **5,131,183** |
| `expired_keys` (TTL-natural) | 2,517,290 |
| `keyspace_hits` | 551,321,018 |
| `keyspace_misses` | 42,845,309 |
| Hit ratio | 92.8% |
| **LRU/TTL ratio** | **~2:1 (forced > natural)** |

A 2:1 LRU-to-TTL ratio is textbook evidence the cache is too small. In a healthy cache most keys leave from TTL expiry; here, two-thirds of removals are forced by memory pressure.

The 7.2% miss rate (43 M misses lifetime) is the slow path for several hottest consumers:
- **Apiunto external-API cache** — each miss is a synchronous HTTP call to `api.star-citizen.wiki` with a 30s timeout, the dominant cost in cold parses during a module-edit cascade.
- **SMW entity cache** (`scw_PROD-wiki:smw:entity`, 79,754 keys) — each miss hits MariaDB.
- **Parser cache** (33K keys, up to 114 KB each) — each miss triggers a full parse.

By far the largest consumer of keys is the S3 file backend stat cache (~247K keys across two prefixes, ~40% of total). That structural pressure isn't going away; the right response is to give the cache more room.

## Safety
`valkey-sts-0` is currently on node `lke86850-757936-31c4f0d50000`:
- `kubectl top nodes`: **4508 MiB / 7853 MiB (57%) used**
- ~3.3 GiB of real free memory
- K8s scheduler-allocated memory limits sum to 5802 MiB (73%)
- Pod container limit is already 4 GiB — this PR doesn't change that, only enables Valkey to use what's allocated

Adding ~1 GiB to Valkey real usage pushes the node from 57% → ~70%. Well within healthy range; no risk of node-level OOM or kubelet eviction.

`maxmemory-policy allkeys-lru` is unchanged. Correct policy for this mixed workload.

## Test plan
- [ ] PR #12 (the auto-restart fix) merges first, so this change rolls valkey-sts cleanly via the existing CI auto-restart logic.
- [ ] After merge: workflow detects `mediawiki/valkey-config.yaml` changed → runs `kubectl rollout restart statefulset/valkey-sts`.
- [ ] New valkey-sts-0 pod starts with `maxmemory 3gb`.
- [ ] Re-run the Valkey Diagnostics workflow ~24h later and verify:
  - `used_memory_human` settles at ~2.5–2.8 GB (not pegged at 3 GB)
  - Rate of new `evicted_keys` is much lower
  - Hit ratio improves
- [ ] Watch for: node memory pressure events (`MemoryPressure` condition on the node), any kubelet pod evictions.

If Valkey pegs at 3 GB and keeps evicting heavily, the structural fix is either moving valkey to the other node (which has 5.97 GiB free) or capping the dominant consumer (S3 stat cache TTL). But based on the data we have, 3 GB should give meaningful breathing room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)