### PR TITLE
Silence nginx apple-touch-icon 404 noise

### DIFF
--- a/mediawiki/nginx-config.yaml
+++ b/mediawiki/nginx-config.yaml
@@ -73,8 +73,13 @@ data:
           }
 
           # Redirect to domain root icons
-          location ~* ^/(?:favicon|apple-touch-icon) {
+          location ~* ^/favicon {
             root /var/www/mediawiki/resources/assets/favicon;
+          }
+          location ~* ^/apple-touch-icon {
+            root /var/www/mediawiki/resources/assets/favicon;
+            log_not_found off;
+            access_log off;
           }
 
           location /images {

--- a/mediawiki/nginx-config.yaml
+++ b/mediawiki/nginx-config.yaml
@@ -76,6 +76,8 @@ data:
           location ~* ^/favicon {
             root /var/www/mediawiki/resources/assets/favicon;
           }
+          # iOS Safari probes legacy variants (-precomposed, -120x120, etc.)
+          # even when apple-touch-icon.png is shipped; silence the 404 noise.
           location ~* ^/apple-touch-icon {
             root /var/www/mediawiki/resources/assets/favicon;
             log_not_found off;

--- a/mediawiki/nginx-config.yaml
+++ b/mediawiki/nginx-config.yaml
@@ -76,6 +76,7 @@ data:
           location ~* ^/favicon {
             root /var/www/mediawiki/resources/assets/favicon;
           }
+
           # iOS Safari probes legacy variants (-precomposed, -120x120, etc.)
           # even when apple-touch-icon.png is shipped; silence the 404 noise.
           location ~* ^/apple-touch-icon {


### PR DESCRIPTION
## Summary
- iOS Safari probes legacy `apple-touch-icon` variants (`-precomposed.png`, `-120x120.png`, `-120x120-precomposed.png`, etc.) even though we ship the modern `apple-touch-icon.png`. These 404s were the #1 source of nginx error-log entries (~269/day, observed in Loki).
- Adds `log_not_found off; access_log off;` inside an `apple-touch-icon` location so the probes stop polluting logs.
- Splits the previous combined `favicon|apple-touch-icon` block so favicon access logs are preserved (relevant now that Plausible is inactive and nginx access logs in Loki are our primary traffic-data source).

## Test plan
- [ ] Roll the ConfigMap and confirm nginx reloads cleanly
- [ ] `curl -I https://starcitizen.tools/apple-touch-icon-precomposed.png` returns 404 (unchanged) but no entry appears in nginx error or access logs
- [ ] `curl -I https://starcitizen.tools/apple-touch-icon.png` still returns 200 and is silent in logs (already 200, now silent)
- [ ] `curl -I https://starcitizen.tools/favicon.ico` still returns 200 **and** still produces an access log entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)