### PR TITLE
Surface SemanticMediaWiki:setupStore errors in logs

### DIFF
--- a/.github/workflows/kubernetes-deploy.yml
+++ b/.github/workflows/kubernetes-deploy.yml
@@ -172,7 +172,12 @@ jobs:
 
       - name: Recent Warning Events
         run: |
-          kubectl get events --sort-by=.lastTimestamp --field-selector type!=Normal | tail -100 || true
+          # Default table output truncates .message, which is exactly where
+          # postStart-hook stderr and other failure details live. Emit full
+          # messages via jsonpath instead.
+          kubectl get events --sort-by=.lastTimestamp --field-selector type!=Normal \
+            -o jsonpath='{range .items[*]}{.lastTimestamp}{"\t"}{.type}{"\t"}{.reason}{"\t"}{.involvedObject.kind}/{.involvedObject.name}{"\t"}{.message}{"\n"}{end}' \
+            | tail -100 || true
 
       - name: Get Pod Names
         id: get-pod-names

--- a/mediawiki/mw-cronjob.yaml
+++ b/mediawiki/mw-cronjob.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-daily
-              image: starcitizentools/mediawiki:smw-26.05.21.542
+              image: starcitizentools/mediawiki:smw-26.05.21.543
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -65,7 +65,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-tridaily
-              image: starcitizentools/mediawiki:smw-26.05.21.542
+              image: starcitizentools/mediawiki:smw-26.05.21.543
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -96,7 +96,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-biweekly
-              image: starcitizentools/mediawiki:smw-26.05.21.542
+              image: starcitizentools/mediawiki:smw-26.05.21.543
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -136,7 +136,7 @@ spec:
           serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-monthly
-              image: starcitizentools/mediawiki:smw-26.05.21.542
+              image: starcitizentools/mediawiki:smw-26.05.21.543
               envFrom:
                 - secretRef:
                     name: mediawiki-keys

--- a/mediawiki/nginx.yaml
+++ b/mediawiki/nginx.yaml
@@ -38,7 +38,7 @@ spec:
                 path: site.conf
       containers:
         - name: nginx
-          image: starcitizentools/nginx:26.05.21.542
+          image: starcitizentools/nginx:26.05.21.543
           # command: [nginx-debug, '-g', 'daemon off;']
           ports:
             - containerPort: 80

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 33
       containers:
         - name: jobrunner
-          image: starcitizentools/mediawiki:smw-jobrunner-26.05.21.542
+          image: starcitizentools/mediawiki:smw-jobrunner-26.05.21.543
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]
@@ -45,7 +45,7 @@ spec:
             - name: smw
               mountPath: /usr/local/smw
         - name: jobchron
-          image: starcitizentools/mediawiki:smw-jobrunner-26.05.21.542
+          image: starcitizentools/mediawiki:smw-jobrunner-26.05.21.543
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -30,6 +30,25 @@ spec:
     spec:
       securityContext:
         fsGroup: 33
+      initContainers:
+        # SMW schema setup. Lives as an initContainer (not a postStart hook) so
+        # its stdout/stderr is captured by the normal log pipeline -- visible in
+        # `kubectl logs -c smw-setup-store`, Loki, and the failure-debug job.
+        # postStart hook output only lands in the Event message, which is
+        # truncated and not shipped anywhere.
+        - name: smw-setup-store
+          image: starcitizentools/mediawiki:smw-26.05.21.542
+          command:
+            - /bin/sh
+            - -c
+            - php /var/www/mediawiki/maintenance/run.php SemanticMediaWiki:setupStore --quiet
+          envFrom:
+            - secretRef:
+                name: mediawiki-keys
+            - secretRef:
+                name: images-keys
+            - secretRef:
+                name: prd-db-password
       containers:
         - name: php-mediawiki
           image: starcitizentools/mediawiki:smw-26.05.21.542
@@ -49,12 +68,3 @@ spec:
                 name: images-keys
             - secretRef:
                 name: prd-db-password
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  [
-                    "/bin/sh",
-                    "-c",
-                    "php /var/www/mediawiki/maintenance/run.php SemanticMediaWiki:setupStore --quiet",
-                  ]

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -37,7 +37,7 @@ spec:
         # postStart hook output only lands in the Event message, which is
         # truncated and not shipped anywhere.
         - name: smw-setup-store
-          image: starcitizentools/mediawiki:smw-26.05.21.542
+          image: starcitizentools/mediawiki:smw-26.05.21.543
           command:
             - /bin/sh
             - -c
@@ -51,7 +51,7 @@ spec:
                 name: prd-db-password
       containers:
         - name: php-mediawiki
-          image: starcitizentools/mediawiki:smw-26.05.21.542
+          image: starcitizentools/mediawiki:smw-26.05.21.543
           ports:
             - containerPort: 9000
           resources:

--- a/shared/backup-cronjob.yaml
+++ b/shared/backup-cronjob.yaml
@@ -172,7 +172,7 @@ spec:
             emptyDir: {}
           containers:
           - name: cronjob-sitemap
-            image: starcitizentools/mediawiki:smw-26.05.21.542
+            image: starcitizentools/mediawiki:smw-26.05.21.543
             resources:
               limits:
                 memory: "512Mi"


### PR DESCRIPTION
## Summary
- Move `SemanticMediaWiki:setupStore` from a `postStart` lifecycle hook to an `initContainer` so its stdout/stderr is captured by the normal log pipeline -- visible in `kubectl logs -c smw-setup-store`, Loki, and the deploy-failure debug job. `postStart` output only lands in the Event `.message`, which is truncated and not shipped anywhere.
- Fix the failure-debug job's "Recent Warning Events" step to emit full event messages via `jsonpath` instead of the default table format, which truncates `.message`.

## Context
Deploy run [26204090019](https://github.com/StarCitizenTools/sct-k8-config/actions/runs/26204090019) failed because the `smw-26.05.21.542` pod kept crash-looping with `FailedPostStartHook`. The debug job ran but neither the kubelet event message nor any log stream surfaced the actual `setupStore` error -- both gaps this PR closes.

Site stays up across the failed rollout (old `.541` replica is still Ready; `maxSurge=100%`, `maxUnavailable=25%`).

## Behavior after merge
- Next deploy will likely **still fail** on `.542` (root cause is in the image), but the init container's stderr will be in `kubectl logs <pod> -c smw-setup-store`, in Loki under the `smw-setup-store` container, and dumped by the existing `--all-containers=true --previous` log step.
- `update-images.sh:58` regex matches both image references in `php-mediawiki.yaml` (uses `/g`), so future bumps stay in sync without changes to the script.

## Test plan
- [ ] Workflow runs on push; deploy step still applies the manifest
- [ ] Debug job's "Recent Warning Events" output now includes full event messages (one event per line, tab-separated)
- [ ] On a failing rollout, `Get Pod Logs` step shows init-container stderr from `smw-setup-store`
- [ ] On a successful rollout, init container completes and FPM starts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)