### PR TITLE
Roll back mediawiki/nginx images to .541

### DIFF
--- a/mediawiki/mw-cronjob.yaml
+++ b/mediawiki/mw-cronjob.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-daily
-              image: starcitizentools/mediawiki:smw-26.05.21.543
+              image: starcitizentools/mediawiki:smw-26.05.19.541
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -65,7 +65,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-tridaily
-              image: starcitizentools/mediawiki:smw-26.05.21.543
+              image: starcitizentools/mediawiki:smw-26.05.19.541
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -96,7 +96,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-biweekly
-              image: starcitizentools/mediawiki:smw-26.05.21.543
+              image: starcitizentools/mediawiki:smw-26.05.19.541
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -136,7 +136,7 @@ spec:
           serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-monthly
-              image: starcitizentools/mediawiki:smw-26.05.21.543
+              image: starcitizentools/mediawiki:smw-26.05.19.541
               envFrom:
                 - secretRef:
                     name: mediawiki-keys

--- a/mediawiki/nginx.yaml
+++ b/mediawiki/nginx.yaml
@@ -38,7 +38,7 @@ spec:
                 path: site.conf
       containers:
         - name: nginx
-          image: starcitizentools/nginx:26.05.21.543
+          image: starcitizentools/nginx:26.05.19.541
           # command: [nginx-debug, '-g', 'daemon off;']
           ports:
             - containerPort: 80

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 33
       containers:
         - name: jobrunner
-          image: starcitizentools/mediawiki:smw-jobrunner-26.05.21.543
+          image: starcitizentools/mediawiki:smw-jobrunner-26.05.19.541
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]
@@ -45,7 +45,7 @@ spec:
             - name: smw
               mountPath: /usr/local/smw
         - name: jobchron
-          image: starcitizentools/mediawiki:smw-jobrunner-26.05.21.543
+          image: starcitizentools/mediawiki:smw-jobrunner-26.05.19.541
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -37,7 +37,7 @@ spec:
         # postStart hook output only lands in the Event message, which is
         # truncated and not shipped anywhere.
         - name: smw-setup-store
-          image: starcitizentools/mediawiki:smw-26.05.21.543
+          image: starcitizentools/mediawiki:smw-26.05.19.541
           command:
             - /bin/sh
             - -c
@@ -51,7 +51,7 @@ spec:
                 name: prd-db-password
       containers:
         - name: php-mediawiki
-          image: starcitizentools/mediawiki:smw-26.05.21.543
+          image: starcitizentools/mediawiki:smw-26.05.19.541
           ports:
             - containerPort: 9000
           resources:

--- a/shared/backup-cronjob.yaml
+++ b/shared/backup-cronjob.yaml
@@ -172,7 +172,7 @@ spec:
             emptyDir: {}
           containers:
           - name: cronjob-sitemap
-            image: starcitizentools/mediawiki:smw-26.05.21.543
+            image: starcitizentools/mediawiki:smw-26.05.19.541
             resources:
               limits:
                 memory: "512Mi"


### PR DESCRIPTION
## Summary
- Revert image tags for mediawiki, jobrunner, and nginx back to the last known-good `.541` versions.
- Keep the initContainer / improved-debug-logging changes from #15 in place.

## Why
Both `.542` and `.543` mediawiki images fail `SemanticMediaWiki:setupStore` (init container, surfaced thanks to #15):

\`\`\`
Error: Call to undefined method SMW\PropertyRegistry::registerPropertyDescriptionMsgKeyById()
from extensions/SemanticExtraSpecialProperties/src/PropertyRegistry.php(128)
\`\`\`

SESP and SMW are at incompatible versions in those images — needs a fix in the image-build repo. Until then, the new `php-mediawiki` ReplicaSet can't become Ready, and the only Ready replica is the existing `.541` pod (`php-mediawiki-76dd7db786-vrxrm`). One eviction (node maintenance, OOM, etc.) and the site goes down.

## What happens on deploy
The `.541` pod template hash matches the still-running `php-mediawiki-76dd7db786` ReplicaSet (1/1 Ready), so K8s should route the Deployment back to that existing RS and scale the failing `.543` RS to 0 — no new pod start required for the main container. The setupStore init container will run against `.541` (same code path the existing pod started with via the prior postStart hook, before #15 moved it to an init container).

## Test plan
- [ ] Deploy workflow succeeds (rollout completes without timeout)
- [ ] `php-mediawiki-76dd7db786` ReplicaSet remains at 1/1 Ready
- [ ] Failing `.543` ReplicaSet (`php-mediawiki-654c4ccd65`) scales to 0
- [ ] Jobs deployment: old `.542` RS (`php-mediawiki-jobs-86c77c9c4f`) stays Ready; new `.543` RS scales to 0
- [ ] Site continues to serve normally

## Follow-up (out of scope)
- Image-build repo: pin SESP/SMW to a compatible pair so future bumps don't trip on this API mismatch
- `mediawiki/php-mediawiki-jobs.yaml` `smw-setup-file` init container uses `items[0]` from `kubectl get pod -l app=php-mediawiki` which is fragile when the new pod is unhealthy — worth hardening separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)