### PR TITLE
Bump MariaDB to 11.8.7

### DIFF
--- a/mediawiki/mariadb.yaml
+++ b/mediawiki/mariadb.yaml
@@ -64,7 +64,7 @@ spec:
         fsGroup: 999
       containers:
         - name: mariadb
-          image: mariadb:11.8.6
+          image: mariadb:11.8.7
           ports:
             - containerPort: 3306 
               name: mariadb-port


### PR DESCRIPTION
## Summary
- `mediawiki/mariadb.yaml`: `mariadb:11.8.6` → `mariadb:11.8.7`

## Test plan
- [ ] Deploy workflow succeeds
- [ ] `mariadb-sts-0` rolls over and comes back Ready
- [ ] Site continues to serve normally after the StatefulSet rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)