### PR TITLE
Share /usr/local/smw between setupStore init and php-mediawiki

### DIFF
--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -36,6 +36,11 @@ spec:
         # `kubectl logs -c smw-setup-store`, Loki, and the failure-debug job.
         # postStart hook output only lands in the Event message, which is
         # truncated and not shipped anywhere.
+        #
+        # setupStore writes the schema upgrade key to /usr/local/smw/.smw.json;
+        # the main container reads it at runtime. The two share the `smw`
+        # emptyDir so the file survives the init->main handoff (same pattern as
+        # the php-mediawiki-jobs Deployment).
         - name: smw-setup-store
           image: starcitizentools/mediawiki:smw-26.05.19.541
           command:
@@ -49,6 +54,9 @@ spec:
                 name: images-keys
             - secretRef:
                 name: prd-db-password
+          volumeMounts:
+            - name: smw
+              mountPath: /usr/local/smw
       containers:
         - name: php-mediawiki
           image: starcitizentools/mediawiki:smw-26.05.19.541
@@ -68,3 +76,9 @@ spec:
                 name: images-keys
             - secretRef:
                 name: prd-db-password
+          volumeMounts:
+            - name: smw
+              mountPath: /usr/local/smw
+      volumes:
+        - name: smw
+          emptyDir: {}


### PR DESCRIPTION
## Summary
Add an `emptyDir` volume `smw` mounted at `/usr/local/smw` on both the `smw-setup-store` initContainer and the main `php-mediawiki` container in `mediawiki/php-mediawiki.yaml`, so `.smw.json` (the SMW schema upgrade key) written by `setupStore` survives the init→main handoff.

## Why
Regression introduced in #15. The previous `postStart` lifecycle hook ran inside the main container, so the file was written and read in the same filesystem. The new initContainer runs in its own filesystem, which is discarded on exit — main container starts empty and the SMW runtime serves:

> Semantic MediaWiki was installed and enabled but is missing an appropriate upgrade key.
>
> ERROR_SCHEMA_INVALID_KEY

on every request. Same shared-volume pattern is already in use by `mediawiki/php-mediawiki-jobs.yaml` for the `smw` emptyDir between the `smw-setup-file` init and the jobrunner/jobchron containers.

## Test plan
- [ ] Deploy succeeds; new RS becomes Ready
- [ ] `kubectl exec` into the new pod and confirm `/usr/local/smw/.smw.json` exists and is non-empty
- [ ] `https://starcitizen.tools/` renders without the ERROR_SCHEMA_INVALID_KEY page (stylesheets/scripts load with `text/css` and `application/javascript` MIME types again)
- [ ] Old `php-mediawiki-77c4679c7-2g8gq` ReplicaSet scales to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)