### PR TITLE
Enable Cloudflare Authenticated Origin Pulls at ingress

### DIFF
--- a/shared/cloudflare-origin-ca.yaml
+++ b/shared/cloudflare-origin-ca.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cloudflare-origin-ca
+    namespace: default
+    annotations:
+        description: >-
+            Cloudflare Authenticated Origin Pulls CA certificate.
+            Used by ingress-nginx to verify TLS client cert presented
+            by Cloudflare on every connection, so requests bypassing
+            Cloudflare (hitting the Linode LB IP directly) are rejected
+            at the TLS layer.
+
+            Source: https://developers.cloudflare.com/ssl/static/authenticated_origin_pull_ca.pem
+            Subject: CN=origin-pull.cloudflare.net
+            Valid: 2019-10-10 to 2029-11-01
+            SHA-256: c14fed0ce5210db0719fea11d1f10b33750dc17d609aeaf47c75e9eff0d7b843
+
+            Cert is public; safe to commit. Rotate the file (and bump
+            kubectl rollout) before Nov 2029.
+type: Opaque
+stringData:
+    ca.crt: |
+        -----BEGIN CERTIFICATE-----
+        MIIGCjCCA/KgAwIBAgIIV5G6lVbCLmEwDQYJKoZIhvcNAQENBQAwgZAxCzAJBgNV
+        BAYTAlVTMRkwFwYDVQQKExBDbG91ZEZsYXJlLCBJbmMuMRQwEgYDVQQLEwtPcmln
+        aW4gUHVsbDEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzETMBEGA1UECBMKQ2FsaWZv
+        cm5pYTEjMCEGA1UEAxMab3JpZ2luLXB1bGwuY2xvdWRmbGFyZS5uZXQwHhcNMTkx
+        MDEwMTg0NTAwWhcNMjkxMTAxMTcwMDAwWjCBkDELMAkGA1UEBhMCVVMxGTAXBgNV
+        BAoTEENsb3VkRmxhcmUsIEluYy4xFDASBgNVBAsTC09yaWdpbiBQdWxsMRYwFAYD
+        VQQHEw1TYW4gRnJhbmNpc2NvMRMwEQYDVQQIEwpDYWxpZm9ybmlhMSMwIQYDVQQD
+        ExpvcmlnaW4tcHVsbC5jbG91ZGZsYXJlLm5ldDCCAiIwDQYJKoZIhvcNAQEBBQAD
+        ggIPADCCAgoCggIBAN2y2zojYfl0bKfhp0AJBFeV+jQqbCw3sHmvEPwLmqDLqynI
+        42tZXR5y914ZB9ZrwbL/K5O46exd/LujJnV2b3dzcx5rtiQzso0xzljqbnbQT20e
+        ihx/WrF4OkZKydZzsdaJsWAPuplDH5P7J82q3re88jQdgE5hqjqFZ3clCG7lxoBw
+        hLaazm3NJJlUfzdk97ouRvnFGAuXd5cQVx8jYOOeU60sWqmMe4QHdOvpqB91bJoY
+        QSKVFjUgHeTpN8tNpKJfb9LIn3pun3bC9NKNHtRKMNX3Kl/sAPq7q/AlndvA2Kw3
+        Dkum2mHQUGdzVHqcOgea9BGjLK2h7SuX93zTWL02u799dr6Xkrad/WShHchfjjRn
+        aL35niJUDr02YJtPgxWObsrfOU63B8juLUphW/4BOjjJyAG5l9j1//aUGEi/sEe5
+        lqVv0P78QrxoxR+MMXiJwQab5FB8TG/ac6mRHgF9CmkX90uaRh+OC07XjTdfSKGR
+        PpM9hB2ZhLol/nf8qmoLdoD5HvODZuKu2+muKeVHXgw2/A6wM7OwrinxZiyBk5Hh
+        CvaADH7PZpU6z/zv5NU5HSvXiKtCzFuDu4/Zfi34RfHXeCUfHAb4KfNRXJwMsxUa
+        +4ZpSAX2G6RnGU5meuXpU5/V+DQJp/e69XyyY6RXDoMywaEFlIlXBqjRRA2pAgMB
+        AAGjZjBkMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgECMB0GA1Ud
+        DgQWBBRDWUsraYuA4REzalfNVzjann3F6zAfBgNVHSMEGDAWgBRDWUsraYuA4REz
+        alfNVzjann3F6zANBgkqhkiG9w0BAQ0FAAOCAgEAkQ+T9nqcSlAuW/90DeYmQOW1
+        QhqOor5psBEGvxbNGV2hdLJY8h6QUq48BCevcMChg/L1CkznBNI40i3/6heDn3IS
+        zVEwXKf34pPFCACWVMZxbQjkNRTiH8iRur9EsaNQ5oXCPJkhwg2+IFyoPAAYURoX
+        VcI9SCDUa45clmYHJ/XYwV1icGVI8/9b2JUqklnOTa5tugwIUi5sTfipNcJXHhgz
+        6BKYDl0/UP0lLKbsUETXeTGDiDpxZYIgbcFrRDDkHC6BSvdWVEiH5b9mH2BON60z
+        0O0j8EEKTwi9jnafVtZQXP/D8yoVowdFDjXcKkOPF/1gIh9qrFR6GdoPVgB3SkLc
+        5ulBqZaCHm563jsvWb/kXJnlFxW+1bsO9BDD6DweBcGdNurgmH625wBXksSdD7y/
+        fakk8DagjbjKShYlPEFOAqEcliwjF45eabL0t27MJV61O/jHzHL3dknXeE4BDa2j
+        bA+JbyJeUMtU7KMsxvx82RmhqBEJJDBCJ3scVptvhDMRrtqDBW5JShxoAOcpFQGm
+        iYWicn46nPDjgTU0bX1ZPpTpryXbvciVL5RkVBuyX2ntcOLDPlZWgxZCBp96x07F
+        AnOzKgZk4RzZPNAxCXERVxajn/FLcOhglVAKo5H0ac+AitlQ0ip55D2/mf8o72tM
+        fVQ6VpyjEXdiIXWUq/o=
+        -----END CERTIFICATE-----

--- a/shared/ingress.yaml
+++ b/shared/ingress.yaml
@@ -50,9 +50,15 @@ metadata:
   namespace: default
   name: nginx-ingress
   annotations:
-    acme.cert-manager.io/http01-edit-in-place: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
+    # Cloudflare Authenticated Origin Pulls: require client cert from
+    # Cloudflare's CA on every TLS connection. Drops traffic that
+    # bypasses CF (e.g. direct hits to the Linode LB IP) at the TLS
+    # layer, before any application code runs.
+    nginx.ingress.kubernetes.io/auth-tls-secret: "default/cloudflare-origin-ca"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
     # nginx.ingress.kubernetes.io/configuration-snippet: |
     #   # Ban very old versions of Chrome. For now we're banning up to Chrome 125.
     #   if ($http_user_agent ~* "Chrome/[0-9]{1,2}\.") { return 403; }


### PR DESCRIPTION
## Summary
- Add `shared/cloudflare-origin-ca.yaml` containing Cloudflare's public AOP CA cert as a K8s Secret (`default/cloudflare-origin-ca`).
- Add three `auth-tls-*` annotations to `shared/ingress.yaml` so ingress-nginx requires a client cert signed by that CA on every TLS connection.
- Drop the stale `acme.cert-manager.io/http01-edit-in-place: "true"` annotation — the `letsencrypt-prod` ClusterIssuer uses DNS01, so this flag has no effect.

## Why
The 2026-05-21 22:57–23:56 UTC outage (59 minutes, ~80 req/min sustained 504s) attribution shows **49% of failing requests had the cluster's node-gateway IP as their "real client IP"** — i.e., the request bypassed Cloudflare, hit the Linode NodeBalancer's public IP directly, and lost the original source IP in the SNAT chain.

That means none of our CF-side protections (UAM rule on Special:* pages, security level, rate-limits, etc.) apply to half of the bot traffic causing outages. AOP closes this hole at the TLS layer — non-CF clients can't complete the handshake.

Same Linode-hosted bot at `139.162.184.58` shows up on both sides of the IP attribution (51% via CF, 49% direct-to-origin), with the same UA-rotation pattern across both paths. Strongly suggests a single actor with knowledge of the origin IP.

## Pre-deploy: done at Cloudflare
**Required before merge:**
- [x] CF dashboard → SSL/TLS → Origin Server → Authenticated Origin Pulls → **On**

Without this, CF doesn't send a client cert and the ingress mTLS verification rejects every request → full outage.

## How the safety story works
| Sequence | Outcome |
|---|---|
| AOP on at CF, then this PR merges | ✓ CF traffic carries valid cert → passes mTLS. Direct-IP traffic has no cert → TLS handshake fails. Desired state. |
| This PR merges without AOP on at CF | ✗ No CF traffic carries a cert → all requests fail the handshake → full outage. |
| AOP on at CF, this PR not yet merged | ✓ CF sends a cert nobody verifies → no-op. Safe steady state until PR lands. |

## Recovery
If the deploy hits a problem, `git revert` this commit → CI redeploys the ingress without the auth-tls annotations → traffic restores within ~2 minutes. No kubectl needed.

## Test plan
- [x] Merge → CI deploys.
- [x] Smoke: open `https://starcitizen.tools/` in a browser → loads normally (via CF).
- [x] Verify lockout: `curl --resolve starcitizen.tools:443:<LB-IP> https://starcitizen.tools/` (substituting the Linode LB public IP) → should fail with a TLS alert (`SSL_ERROR_BAD_CERT_ALERT` or equivalent), NOT a successful response.
- [ ] BetterStack: all five monitors stay green (they all go via Cloudflare, so they get the cert).
- [ ] Loki: in the next outage event, re-run the IP attribution; the `10.2.0.129` (node-gateway) row should be gone or near-zero.

## Cert lifetime
Cloudflare's AOP CA expires 2029-11-01 (4+ years out). When CF rotates the CA, replace the cert content in `shared/cloudflare-origin-ca.yaml` and bump. The Secret name and ingress annotation references don't change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)