### PR TITLE
Add ingress-tls-diagnostics workflow

### DIFF
--- a/.github/workflows/ingress-tls-diagnostics.yml
+++ b/.github/workflows/ingress-tls-diagnostics.yml
@@ -81,6 +81,20 @@ jobs:
           #   "unknown ca"
           PATTERN='No required SSL certificate|SSL certificate verify error|SSL_do_handshake|SSL handshake|self signed certificate|unknown ca'
 
+          # IP masking: client IPs are personal data (GDPR, settled case
+          # law). GHA logs persist ~90 days and are readable by anyone
+          # with repo access, so we mask IPv4 to /24 and IPv6 to /64
+          # before printing or aggregating. /24 still preserves enough
+          # signal to identify "this is a Linode datacenter range" /
+          # "this is a hosting provider" without exposing the specific
+          # host. If you need /32-level data to actually block an IP,
+          # pull it from kubectl logs directly outside CI.
+          mask_ips() {
+            sed -E \
+              -e 's/(client: [0-9]+\.[0-9]+\.[0-9]+)\.[0-9]+/\1.0/g' \
+              -e 's/(client: [0-9a-fA-F]+:[0-9a-fA-F]+:[0-9a-fA-F]+:[0-9a-fA-F]+):[0-9a-fA-F:]+/\1::/g'
+          }
+
           while IFS= read -r p; do
             [[ -z "$p" ]] && continue
             NS=$(echo "$p" | cut -d/ -f1)
@@ -89,6 +103,7 @@ jobs:
             kubectl logs -n "$NS" "$NAME" --since="${SINCE}" --tail="${MAX_LINES}" 2>&1 \
               | grep -E -i "$PATTERN" \
               | tee -a "$ALL_LOG" \
+              | mask_ips \
               | head -50  # cap per-pod stdout for readability
             echo "::endgroup::"
           done <<< "$PODS"
@@ -102,10 +117,13 @@ jobs:
             echo "Cloudflare right now, or the look-back window was too short."
             exit 0
           fi
+          echo "(IPs below are masked to /24 for IPv4 and /64 for IPv6.)"
           echo "::endgroup::"
 
-          echo "::group::Top 30 client IPs hitting the TLS wall"
-          grep -oE 'client: [0-9.]+' "$ALL_LOG" | sort | uniq -c | sort -rn | head -30
+          echo "::group::Top 30 client subnets hitting the TLS wall (/24 or /64)"
+          grep -oE 'client: ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|[0-9a-fA-F:]+)' "$ALL_LOG" \
+            | mask_ips \
+            | sort | uniq -c | sort -rn | head -30
           echo "::endgroup::"
 
           echo "::group::Top 20 SNI hosts requested (what hostnames are being probed)"
@@ -116,6 +134,6 @@ jobs:
           grep -oE 'server: [^,]+' "$ALL_LOG" | sort | uniq -c | sort -rn | head -20
           echo "::endgroup::"
 
-          echo "::group::Sample of 20 raw matching log lines"
-          head -20 "$ALL_LOG"
+          echo "::group::Sample of 20 raw matching log lines (with IPs masked)"
+          head -20 "$ALL_LOG" | mask_ips
           echo "::endgroup::"

--- a/.github/workflows/ingress-tls-diagnostics.yml
+++ b/.github/workflows/ingress-tls-diagnostics.yml
@@ -1,0 +1,121 @@
+name: Ingress TLS Diagnostics
+
+# Pulls ingress-nginx logs and surfaces TLS handshake failures (mostly
+# Authenticated Origin Pulls rejections after PR #19). Useful for
+# answering "what's trying to hit our origin without going through
+# Cloudflare?"
+#
+# Run manually from the Actions tab. Look at the workflow output, not
+# job artifacts -- everything is written to the step output streams.
+
+on:
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "How far back to look at logs (e.g. 1h, 30m, 6h)"
+        required: false
+        default: "1h"
+        type: string
+      max_lines:
+        description: "Max log lines to scan per pod"
+        required: false
+        default: "100000"
+        type: string
+
+jobs:
+  ingress-tls-info:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: azure/setup-kubectl@v4
+
+      - name: Kubernetes Set Context
+        uses: Azure/k8s-set-context@v4
+        with:
+          cluster-type: generic
+          method: kubeconfig
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+
+      - name: Locate ingress-nginx controller pods
+        id: find-pods
+        run: |
+          set -eo pipefail
+          PODS=$(kubectl get pods -A \
+            -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller \
+            -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
+          if [[ -z "$PODS" ]]; then
+            echo "No ingress-nginx controller pods found via standard labels."
+            echo "Falling back to broader pod-name search..."
+            PODS=$(kubectl get pods -A -o name 2>/dev/null \
+              | grep -E "ingress.*nginx|nginx.*ingress" \
+              | sed 's|pod/||')
+          fi
+          if [[ -z "$PODS" ]]; then
+            echo "Still no ingress-nginx pods found. Listing all namespaces for context:"
+            kubectl get ns
+            exit 1
+          fi
+          echo "Found pods:"
+          printf '  %s\n' $PODS
+          echo "pods<<EOF" >> $GITHUB_OUTPUT
+          echo "$PODS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Collect TLS handshake failures
+        env:
+          PODS: ${{ steps.find-pods.outputs.pods }}
+          SINCE: ${{ inputs.since }}
+          MAX_LINES: ${{ inputs.max_lines }}
+        run: |
+          set -eo pipefail
+
+          WORKDIR=$(mktemp -d)
+          ALL_LOG="$WORKDIR/all-ssl-errors.log"
+          : > "$ALL_LOG"
+
+          # Patterns we care about (case-insensitive):
+          #   "No required SSL certificate"  → AOP rejection (the headline event)
+          #   "client SSL certificate verify error"
+          #   "SSL_do_handshake() failed"
+          #   "peer closed connection in SSL handshake"
+          #   "self signed certificate"
+          #   "unknown ca"
+          PATTERN='No required SSL certificate|SSL certificate verify error|SSL_do_handshake|SSL handshake|self signed certificate|unknown ca'
+
+          while IFS= read -r p; do
+            [[ -z "$p" ]] && continue
+            NS=$(echo "$p" | cut -d/ -f1)
+            NAME=$(echo "$p" | cut -d/ -f2)
+            echo "::group::Logs for $p"
+            kubectl logs -n "$NS" "$NAME" --since="${SINCE}" --tail="${MAX_LINES}" 2>&1 \
+              | grep -E -i "$PATTERN" \
+              | tee -a "$ALL_LOG" \
+              | head -50  # cap per-pod stdout for readability
+            echo "::endgroup::"
+          done <<< "$PODS"
+
+          TOTAL=$(wc -l < "$ALL_LOG")
+          echo
+          echo "::group::Summary"
+          echo "Total matching log lines across all pods: $TOTAL"
+          if [[ "$TOTAL" -eq 0 ]]; then
+            echo "No TLS handshake failures found. Either nothing is bypassing"
+            echo "Cloudflare right now, or the look-back window was too short."
+            exit 0
+          fi
+          echo "::endgroup::"
+
+          echo "::group::Top 30 client IPs hitting the TLS wall"
+          grep -oE 'client: [0-9.]+' "$ALL_LOG" | sort | uniq -c | sort -rn | head -30
+          echo "::endgroup::"
+
+          echo "::group::Top 20 SNI hosts requested (what hostnames are being probed)"
+          grep -oE 'host: "[^"]*"' "$ALL_LOG" | sort | uniq -c | sort -rn | head -20
+          echo "::endgroup::"
+
+          echo "::group::Top 20 server names (per ingress-nginx server block)"
+          grep -oE 'server: [^,]+' "$ALL_LOG" | sort | uniq -c | sort -rn | head -20
+          echo "::endgroup::"
+
+          echo "::group::Sample of 20 raw matching log lines"
+          head -20 "$ALL_LOG"
+          echo "::endgroup::"


### PR DESCRIPTION
## Summary
New `workflow_dispatch`-triggered job (`.github/workflows/ingress-tls-diagnostics.yml`) that pulls ingress-nginx controller pod logs, greps for TLS handshake failure patterns, and aggregates by client IP / SNI host / server block.

## Why
After #19 enabled Cloudflare Authenticated Origin Pulls, requests that don't come from CF get rejected at the TLS layer. ingress-nginx logs each rejection (typically as `client sent no required SSL certificate`), but those logs **aren't shipped to Loki** -- alloy only scrapes the `default` and `monitoring` namespaces, not `ingress-nginx`. Without this workflow, the only way to see what's being rejected is `kubectl logs`, which we don't have shell access for.

This workflow gives us a queryable answer to "what's hitting our origin without going through Cloudflare?" -- run it after a suspicious period and the output shows the source IPs and hostnames hammering at our origin.

## Inputs
- `since` (default `1h`): how far back to scan. Use `6h` for broader sweep.
- `max_lines` (default `100000`): cap per-pod lines scanned, to keep memory sane on busy clusters.

## Output (printed in the step log, no artifacts)
- Total matching lines
- Top 30 client IPs hitting the TLS wall
- Top 20 SNI hostnames being requested (will mostly be `starcitizen.tools`, but other hostnames would hint at hostname probing)
- Top 20 ingress-nginx server names
- Sample of 20 raw log lines

## Patterns matched (case-insensitive)
- `No required SSL certificate` -- the headline AOP rejection
- `SSL certificate verify error`
- `SSL_do_handshake`
- `SSL handshake`
- `self signed certificate`
- `unknown ca`

## Test plan
- [ ] Merge → workflow appears in Actions tab.
- [ ] Trigger once manually with default `since: 1h`. Output should show:
  - Either non-zero matches (meaning bypass attempts are still happening, now visible) with the source IPs we want to see, **or**
  - Zero matches (meaning either nothing is bypassing, or the look-back window missed a quiet period).
- [ ] If zero, rerun with `since: 6h` or `since: 24h` to catch more.

## Future
The structural fix is to add ingress-nginx logs to alloy's scrape config (Option B from our discussion) so this becomes a normal Loki query. That requires touching wherever alloy is configured (not visible from this repo), which is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)