### PR TITLE
Wire UEX_APITOKEN into MediaWiki containers

### DIFF
--- a/.github/workflows/kubernetes-deploy.yml
+++ b/.github/workflows/kubernetes-deploy.yml
@@ -27,6 +27,17 @@ jobs:
           secret-name: mediawiki-keys
           data: ${{ secrets.MEDIAWIKI_KEYS }}
 
+      # UEX_APITOKEN must be stored as a JSON object -- the action runs the
+      # input through JSON.parse -- with the key UEX_APITOKEN, which is the
+      # env var LocalSettings reads via getenv() and that envFrom exposes:
+      #   {"UEX_APITOKEN":"<token>"}
+      - name: UEX_APITOKEN Secret
+        uses: Azure/k8s-create-secret@v5
+        with:
+          secret-type: 'generic'
+          secret-name: uex-keys
+          string-data: ${{ secrets.UEX_APITOKEN }}
+
       - name: PRD_DB_PASSWORD Secret
         uses: Azure/k8s-create-secret@v5
         with:

--- a/mediawiki/mw-cronjob.yaml
+++ b/mediawiki/mw-cronjob.yaml
@@ -22,6 +22,8 @@ spec:
                     name: prd-db-password
                 - secretRef:
                     name: images-keys
+                - secretRef:
+                    name: uex-keys
               volumeMounts:
                 - name: smw
                   mountPath: /usr/local/smw
@@ -73,6 +75,8 @@ spec:
                     name: prd-db-password
                 - secretRef:
                     name: images-keys
+                - secretRef:
+                    name: uex-keys
               command: ["/bin/sh"]
               args:
                 - -c
@@ -104,6 +108,8 @@ spec:
                     name: prd-db-password
                 - secretRef:
                     name: images-keys
+                - secretRef:
+                    name: uex-keys
               command: ["/bin/sh"]
               args:
                 - -c
@@ -144,6 +150,8 @@ spec:
                     name: prd-db-password
                 - secretRef:
                     name: images-keys
+                - secretRef:
+                    name: uex-keys
               volumeMounts:
                 - name: smw
                   mountPath: /usr/local/smw

--- a/mediawiki/mw-cronjob.yaml
+++ b/mediawiki/mw-cronjob.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-daily
-              image: starcitizentools/mediawiki:smw-26.05.25.548
+              image: starcitizentools/mediawiki:smw-26.05.25.549
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -67,7 +67,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-tridaily
-              image: starcitizentools/mediawiki:smw-26.05.25.548
+              image: starcitizentools/mediawiki:smw-26.05.25.549
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -100,7 +100,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-biweekly
-              image: starcitizentools/mediawiki:smw-26.05.25.548
+              image: starcitizentools/mediawiki:smw-26.05.25.549
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -142,7 +142,7 @@ spec:
           serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-monthly
-              image: starcitizentools/mediawiki:smw-26.05.25.548
+              image: starcitizentools/mediawiki:smw-26.05.25.549
               envFrom:
                 - secretRef:
                     name: mediawiki-keys

--- a/mediawiki/nginx.yaml
+++ b/mediawiki/nginx.yaml
@@ -38,7 +38,7 @@ spec:
                 path: site.conf
       containers:
         - name: nginx
-          image: starcitizentools/nginx:26.05.25.548
+          image: starcitizentools/nginx:26.05.25.549
           # command: [nginx-debug, '-g', 'daemon off;']
           ports:
             - containerPort: 80

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -41,6 +41,8 @@ spec:
                 name: prd-db-password
             - secretRef:
                 name: images-keys
+            - secretRef:
+                name: uex-keys
           volumeMounts:
             - name: smw
               mountPath: /usr/local/smw

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 33
       containers:
         - name: jobrunner
-          image: starcitizentools/mediawiki:smw-jobrunner-26.05.25.548
+          image: starcitizentools/mediawiki:smw-jobrunner-26.05.25.549
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]
@@ -47,7 +47,7 @@ spec:
             - name: smw
               mountPath: /usr/local/smw
         - name: jobchron
-          image: starcitizentools/mediawiki:smw-jobrunner-26.05.25.548
+          image: starcitizentools/mediawiki:smw-jobrunner-26.05.25.549
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -42,7 +42,7 @@ spec:
         # emptyDir so the file survives the init->main handoff (same pattern as
         # the php-mediawiki-jobs Deployment).
         - name: smw-setup-store
-          image: starcitizentools/mediawiki:smw-26.05.25.548
+          image: starcitizentools/mediawiki:smw-26.05.25.549
           command:
             - /bin/sh
             - -c
@@ -59,7 +59,7 @@ spec:
               mountPath: /usr/local/smw
       containers:
         - name: php-mediawiki
-          image: starcitizentools/mediawiki:smw-26.05.25.548
+          image: starcitizentools/mediawiki:smw-26.05.25.549
           ports:
             - containerPort: 9000
           resources:

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -76,6 +76,8 @@ spec:
                 name: images-keys
             - secretRef:
                 name: prd-db-password
+            - secretRef:
+                name: uex-keys
           volumeMounts:
             - name: smw
               mountPath: /usr/local/smw

--- a/shared/backup-cronjob.yaml
+++ b/shared/backup-cronjob.yaml
@@ -172,7 +172,7 @@ spec:
             emptyDir: {}
           containers:
           - name: cronjob-sitemap
-            image: starcitizentools/mediawiki:smw-26.05.25.548
+            image: starcitizentools/mediawiki:smw-26.05.25.549
             resources:
               limits:
                 memory: "512Mi"


### PR DESCRIPTION
## What

Provisions the `UEX_APITOKEN` required by [sct-docker-images@6337614](https://github.com/StarCitizenTools/sct-docker-images/commit/63376147625a7656fcca3ee490fefb6d793c331c), which registers the UEX 2.0 trade API as an Apiunto source read via `getenv("UEX_APITOKEN")`, and bumps the Docker images to pick it up.

## Changes

**Wire `UEX_APITOKEN`:**
- **Deploy workflow**: new `UEX_APITOKEN Secret` step creates a `uex-keys` k8s secret via `Azure/k8s-create-secret`, consistent with the other secret steps.
- **Manifests**: `uex-keys` added to `envFrom` on the containers that actually parse wikitext (where the Apiunto source fetches) — the web pods (`php-mediawiki`), the `jobrunner`, and the four `mw-cronjob` maintenance crons. Setup/init containers, `jobchron`, and the backup job are skipped since they never parse content.

**Bump Docker images** (`update-images.sh`): `26.05.25.548` → `26.05.25.549` across mediawiki, jobrunner, nginx, and backup.

## ⚠️ Required before merge/deploy

1. The `UEX_APITOKEN` GitHub Actions secret must be stored as a **JSON object**, not a raw token — `Azure/k8s-create-secret` runs the input through `JSON.parse`, and the key becomes the env var name:
   ```json
   {"UEX_APITOKEN":"<token>"}
   ```
   If left as a raw token, the deploy step fails on `JSON.parse`.

2. Confirm image tag `26.05.25.549` actually carries commit `6337614` — otherwise the env var has nothing reading it yet.

Pushing to `smw` (on merge) triggers the production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)