### PR TITLE
Repoint app images to GHCR + add GHCR pull secret

### DIFF
--- a/.github/workflows/kubernetes-deploy.yml
+++ b/.github/workflows/kubernetes-deploy.yml
@@ -106,17 +106,33 @@ jobs:
             --namespace=default \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      # Attach the pull secret to the service accounts every pod runs as, so
-      # all docker.io pulls authenticate without editing individual manifests.
-      # imagePullSecrets on a SA only applies to newly-created pods, so this
-      # takes effect on each workload's next rollout (the deploy below).
+      # Our app images (starcitizentools/*) live in GHCR as private packages,
+      # so the kubelet needs credentials to pull them. Uses a read:packages
+      # PAT; this can be dropped if the packages are ever made public.
+      - name: GHCR pull secret
+        env:
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: |
+          set -euo pipefail
+          kubectl create secret docker-registry ghcr-pull \
+            --docker-server=ghcr.io \
+            --docker-username="$GHCR_USERNAME" \
+            --docker-password="$GHCR_TOKEN" \
+            --namespace=default \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      # Attach both pull secrets to the service accounts every pod runs as, so
+      # docker.io and ghcr.io pulls authenticate without editing individual
+      # manifests. imagePullSecrets on a SA only applies to newly-created pods,
+      # so this takes effect on each workload's next rollout (the deploy below).
       - name: Attach pull secret to service accounts
         run: |
           set -euo pipefail
           for sa in default internal-kubectl; do
             if kubectl get serviceaccount "$sa" -n default >/dev/null 2>&1; then
               kubectl patch serviceaccount "$sa" -n default \
-                -p '{"imagePullSecrets":[{"name":"dockerhub-pull"}]}'
+                -p '{"imagePullSecrets":[{"name":"dockerhub-pull"},{"name":"ghcr-pull"}]}'
               echo "Patched serviceaccount/$sa with imagePullSecrets."
             else
               echo "::warning::serviceaccount/$sa not found; skipping (will inherit on a later run)."
@@ -130,6 +146,14 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+
+      # Also log into GHCR so the tag-existence inspects below can read our
+      # private app-image packages.
+      - name: GHCR login (runner)
+        env:
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       # Guard 1: fail fast if any manifest references an image tag that does
       # not exist in the registry. A typo'd/non-existent tag otherwise leaves

--- a/mediawiki/mw-cronjob.yaml
+++ b/mediawiki/mw-cronjob.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-daily
-              image: starcitizentools/mediawiki:smw-26.06.01.559
+              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.02.561
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -67,7 +67,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-tridaily
-              image: starcitizentools/mediawiki:smw-26.06.01.559
+              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.02.561
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -100,7 +100,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-biweekly
-              image: starcitizentools/mediawiki:smw-26.06.01.559
+              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.02.561
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -142,7 +142,7 @@ spec:
           serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-monthly
-              image: starcitizentools/mediawiki:smw-26.06.01.559
+              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.02.561
               envFrom:
                 - secretRef:
                     name: mediawiki-keys

--- a/mediawiki/nginx.yaml
+++ b/mediawiki/nginx.yaml
@@ -38,7 +38,7 @@ spec:
                 path: site.conf
       containers:
         - name: nginx
-          image: starcitizentools/nginx:26.06.01.558
+          image: ghcr.io/starcitizentools/nginx:26.06.02.561
           # command: [nginx-debug, '-g', 'daemon off;']
           ports:
             - containerPort: 80

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 33
       containers:
         - name: jobrunner
-          image: starcitizentools/mediawiki:smw-jobrunner-26.06.01.559
+          image: ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.02.561
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]
@@ -47,7 +47,7 @@ spec:
             - name: smw
               mountPath: /usr/local/smw
         - name: jobchron
-          image: starcitizentools/mediawiki:smw-jobrunner-26.06.01.559
+          image: ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.02.561
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -42,7 +42,7 @@ spec:
         # emptyDir so the file survives the init->main handoff (same pattern as
         # the php-mediawiki-jobs Deployment).
         - name: smw-setup-store
-          image: starcitizentools/mediawiki:smw-26.06.01.559
+          image: ghcr.io/starcitizentools/mediawiki:smw-26.06.02.561
           command:
             - /bin/sh
             - -c
@@ -59,7 +59,7 @@ spec:
               mountPath: /usr/local/smw
       containers:
         - name: php-mediawiki
-          image: starcitizentools/mediawiki:smw-26.06.01.559
+          image: ghcr.io/starcitizentools/mediawiki:smw-26.06.02.561
           ports:
             - containerPort: 9000
           resources:

--- a/shared/backup-cronjob.yaml
+++ b/shared/backup-cronjob.yaml
@@ -172,7 +172,7 @@ spec:
             emptyDir: {}
           containers:
           - name: cronjob-sitemap
-            image: starcitizentools/mediawiki:smw-26.06.01.559
+            image: ghcr.io/starcitizentools/mediawiki:smw-26.06.02.561
             resources:
               limits:
                 memory: "512Mi"


### PR DESCRIPTION
Completes the consumer side of the GHCR migration (publishing side: sct-docker-images#29). The GHCR packages are **private** and can't be made public (no permission), so this PR both repoints the images and wires up authenticated pulls.

## 1. Repoint image refs (10)
- `starcitizentools/mediawiki:smw-26.06.01.559` → `ghcr.io/starcitizentools/mediawiki:smw-26.06.02.561` (×7)
- `starcitizentools/mediawiki:smw-jobrunner-26.06.01.559` → `ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.02.561` (×2)
- `starcitizentools/nginx:26.06.01.558` → `ghcr.io/starcitizentools/nginx:26.06.02.561` (×1)

Also a version bump (`…01.559`→`…02.561`): the old tags only exist on Docker Hub; the GHCR-only build produced `26.06.02.561`. Pinned `MEDIAWIKI_COMMIT_HASH` is unchanged, so it's the same app rebuilt.

## 2. GHCR pull secret (deploy workflow)
- New `GHCR pull secret` step → creates a `ghcr-pull` docker-registry secret (`ghcr.io`) in `default`.
- `Attach pull secret to service accounts` now attaches **both** `dockerhub-pull` and `ghcr-pull` to the `default` and `internal-kubectl` SAs.
- New `GHCR login (runner)` step so the tag-check can inspect the private packages.

## ⚠️ Required before merge: add repo secrets
Create a **classic PAT with `read:packages`** (or fine-grained token with packages: read) for an account that can read the org's packages, then add repo secrets:
- `GHCR_USERNAME` = the GitHub username that owns the token
- `GHCR_TOKEN` = the PAT

Merging to `smw` triggers a live deploy; without these secrets the `ghcr-pull` secret is created with empty creds and pulls fail (the tag-check guard would also fail first). If the packages are later made public, this wiring can be removed.