### PR TITLE
Drop obsolete .smw.json setup machinery

### DIFF
--- a/mediawiki/mw-cronjob.yaml
+++ b/mediawiki/mw-cronjob.yaml
@@ -11,7 +11,6 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-daily
               image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
@@ -24,9 +23,6 @@ spec:
                     name: images-keys
                 - secretRef:
                     name: uex-keys
-              volumeMounts:
-                - name: smw
-                  mountPath: /usr/local/smw
               command: ["/bin/sh"]
               args:
                 - -c
@@ -37,19 +33,6 @@ spec:
                   php /var/www/mediawiki/maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities &&
                   php /var/www/mediawiki/maintenance/run.php SemanticMediaWiki:rebuildPropertyStatistics &&
                   php /var/www/mediawiki/maintenance/run.php SemanticMediaWiki:rebuildConceptCache --update --create
-          initContainers:
-            - name: smw-setup-file
-              image: bitnami/kubectl:latest
-              command:
-                - /bin/sh
-                - -c
-                - POD=$(kubectl get pod -l app=php-mediawiki -o jsonpath='{.items[0].metadata.name}') && kubectl cp $POD:/usr/local/smw/.smw.json /usr/local/smw/.smw.json
-              volumeMounts:
-                - name: smw
-                  mountPath: /usr/local/smw
-          volumes:
-            - name: smw
-              emptyDir: {}
           restartPolicy: OnFailure
 ---
 apiVersion: batch/v1
@@ -139,7 +122,6 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: internal-kubectl
           containers:
             - name: cronjob-mw-monthly
               image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
@@ -152,9 +134,6 @@ spec:
                     name: images-keys
                 - secretRef:
                     name: uex-keys
-              volumeMounts:
-                - name: smw
-                  mountPath: /usr/local/smw
               command: ["/bin/sh"]
               args:
                 - -c
@@ -163,17 +142,4 @@ spec:
                   php /var/www/mediawiki/maintenance/run.php cleanupWatchlist --fix &&
                   php /var/www/mediawiki/maintenance/run.php refreshLinks --dfn-only &&
                   php /var/www/mediawiki/maintenance/run.php SemanticMediaWiki:removeDuplicateEntities
-          initContainers:
-            - name: smw-setup-file
-              image: bitnami/kubectl:latest
-              command:
-                - /bin/sh
-                - -c
-                - POD=$(kubectl get pod -l app=php-mediawiki -o jsonpath='{.items[0].metadata.name}') && kubectl cp $POD:/usr/local/smw/.smw.json /usr/local/smw/.smw.json
-              volumeMounts:
-                - name: smw
-                  mountPath: /usr/local/smw
-          volumes:
-            - name: smw
-              emptyDir: {}
           restartPolicy: OnFailure

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: php-mediawiki-jobs
     spec:
-      serviceAccountName: internal-kubectl
       securityContext:
         fsGroup: 33
         runAsUser: 33
@@ -43,9 +42,6 @@ spec:
                 name: images-keys
             - secretRef:
                 name: uex-keys
-          volumeMounts:
-            - name: smw
-              mountPath: /usr/local/smw
         - name: jobchron
           image: ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.06.566
           command: ["/bin/sh"]
@@ -66,16 +62,3 @@ spec:
           env:
             - name: RUNNER_TYPE
               value: Chron
-      initContainers:
-        - name: smw-setup-file
-          image: bitnami/kubectl:latest
-          command:
-            - /bin/sh
-            - -c
-            - POD=$(kubectl get pod -l app=php-mediawiki -o jsonpath='{.items[0].metadata.name}') && kubectl cp $POD:/usr/local/smw/.smw.json /usr/local/smw/.smw.json
-          volumeMounts:
-            - name: smw
-              mountPath: /usr/local/smw
-      volumes:
-        - name: smw
-          emptyDir: {}

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -37,10 +37,9 @@ spec:
         # postStart hook output only lands in the Event message, which is
         # truncated and not shipped anywhere.
         #
-        # setupStore writes the schema upgrade key to /usr/local/smw/.smw.json;
-        # the main container reads it at runtime. The two share the `smw`
-        # emptyDir so the file survives the init->main handoff (same pattern as
-        # the php-mediawiki-jobs Deployment).
+        # SMW 7 dropped the .smw.json upgrade-key file, so this init no longer
+        # shares anything with the main container -- setupStore just applies any
+        # pending SMW store schema changes against the DB.
         - name: smw-setup-store
           image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
           command:
@@ -54,9 +53,6 @@ spec:
                 name: images-keys
             - secretRef:
                 name: prd-db-password
-          volumeMounts:
-            - name: smw
-              mountPath: /usr/local/smw
       containers:
         - name: php-mediawiki
           image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
@@ -78,9 +74,3 @@ spec:
                 name: prd-db-password
             - secretRef:
                 name: uex-keys
-          volumeMounts:
-            - name: smw
-              mountPath: /usr/local/smw
-      volumes:
-        - name: smw
-          emptyDir: {}


### PR DESCRIPTION
## Summary

SMW 7 removed the `.smw.json` upgrade-key file. The init-container chain built to generate and distribute it is now dead weight — and it was **wedging deploy rollouts** (latest failure: [run 27052565025](https://github.com/StarCitizenTools/sct-k8-config/actions/runs/27052565025), ~11m before timing out).

### Root cause of the rollout hang
The `smw-setup-file` init (in `php-mediawiki-jobs` and the daily/monthly cronjobs) ran:
```sh
POD=$(kubectl get pod -l app=php-mediawiki -o jsonpath='{.items[0].metadata.name}') \
  && kubectl cp $POD:/usr/local/smw/.smw.json /usr/local/smw/.smw.json
```
During a rolling update (`maxSurge: 100%`) the `app=php-mediawiki` selector matches **both** the old (Ready) and the new (still-initializing) pod. When `items[0]` resolved to the new pod, whose `php-mediawiki` container wasn't running yet, `kubectl cp` couldn't exec into it → the init hung → the Deployment hit `ProgressDeadlineExceeded`.

## Changes
- **php-mediawiki**: keep the `setupStore` init (still needed for SMW store schema updates on deploy), but drop the `smw` emptyDir and both mounts — SMW 7 no longer needs the init→main `.smw.json` handoff.
- **php-mediawiki-jobs** + **daily/monthly cronjobs**: remove the `smw-setup-file` `kubectl cp` init and the `smw` emptyDir entirely.
- Remove the now-orphaned `serviceAccountName: internal-kubectl` from those workloads (it existed only for the removed `kubectl cp`; the SA is still defined and used by the backup cronjob).

3 files, +3 / −64. All YAML validated.

## Not addressed here
The same failed run also showed **nginx** failing its rollout, which is **not** related to `.smw.json` (nginx has no init container or `.smw.json` dependency). Investigating separately — likely a slow/stuck GHCR pull, since the deploy workflow only pre-pulls StatefulSet images, not Deployment images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)