### PR TITLE
CI: failure-debug + Deployment pre-pull hardening; bump images to 567

### DIFF
--- a/.github/workflows/kubernetes-deploy.yml
+++ b/.github/workflows/kubernetes-deploy.yml
@@ -251,6 +251,85 @@ jobs:
             echo "::endgroup::"
           done
 
+      # Guard 3: warm changed Deployment images on EVERY node before the
+      # rollout. Unlike the StatefulSets above, Deployment pods (nginx,
+      # php-mediawiki, jobs) are not node-pinned -- a surge pod can land on any
+      # node, so an inline first-pull would run on the rollout's 10m clock.
+      # Pulling ahead keeps it off that clock; and because each pull is pinned
+      # to a node, a node whose runtime is wedged (Ready but unable to start
+      # pods -- the 2026-06-06 failure mode) surfaces here as a named warning
+      # instead of an opaque rollout timeout. Best-effort: a stuck node warns
+      # but does not fail the deploy, since the surge pod may still schedule
+      # onto a healthy node. No secrets are emitted -- only image and node names.
+      - name: Pre-pull changed Deployment images (all nodes)
+        run: |
+          set -euo pipefail
+          # workload -> "manifest file|image-repo needle" (needle is unique per file)
+          declare -A DEPLOY=(
+            ["nginx"]="mediawiki/nginx.yaml|ghcr.io/starcitizentools/nginx:"
+            ["php-mediawiki"]="mediawiki/php-mediawiki.yaml|ghcr.io/starcitizentools/mediawiki:smw-"
+            ["php-mediawiki-jobs"]="mediawiki/php-mediawiki-jobs.yaml|ghcr.io/starcitizentools/mediawiki:smw-jobrunner-"
+          )
+
+          # Collect desired images that differ from what each Deployment runs now.
+          changed_images=()
+          for name in "${!DEPLOY[@]}"; do
+            IFS='|' read -r file needle <<<"${DEPLOY[$name]}"
+            desired=$(grep -hE "^[[:space:]]*image:[[:space:]]*${needle}" "$file" \
+              | head -1 | sed -E 's/^[[:space:]]*image:[[:space:]]*//; s/[[:space:]].*$//')
+            if [ -z "$desired" ]; then
+              echo "::warning::Could not find ${needle}* image in ${file}; skipping ${name}."
+              continue
+            fi
+            running=$(kubectl get deployment "$name" \
+              -o jsonpath='{.spec.template.spec.containers[*].image}{" "}{.spec.template.spec.initContainers[*].image}' 2>/dev/null \
+              | tr ' ' '\n' | grep -E "^${needle}" | head -1 || true)
+            if [ "$desired" = "$running" ]; then
+              echo "${name} already at ${desired}; no pre-pull needed."
+            else
+              echo "${name}: ${running:-<none>} -> ${desired} (will warm)."
+              changed_images+=("$desired")
+            fi
+          done
+
+          if [ "${#changed_images[@]}" -eq 0 ]; then
+            echo "No changed Deployment images; nothing to pre-pull."
+            exit 0
+          fi
+
+          # Render one no-op container per image (printf keeps indentation exact,
+          # independent of this YAML block's own indentation).
+          containers_yaml=""
+          idx=0
+          for img in "${changed_images[@]}"; do
+            containers_yaml+=$(printf '        - name: pull-%s\n          image: %s\n          imagePullPolicy: IfNotPresent\n          command: ["/bin/sh", "-c", "exit 0"]\n' "$idx" "$img")
+            containers_yaml+=$'\n'
+            idx=$((idx + 1))
+          done
+
+          # One pull Job per node, pinned via nodeName. The pod inherits the
+          # default SA's imagePullSecrets (patched earlier), so private GHCR
+          # pulls authenticate.
+          node_idx=0
+          for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+            job="prepull-deploy-${node_idx}"
+            node_idx=$((node_idx + 1))
+            echo "::group::Warm ${#changed_images[@]} image(s) on ${node}"
+            kubectl delete job "$job" --ignore-not-found
+            printf 'apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: %s\nspec:\n  backoffLimit: 0\n  ttlSecondsAfterFinished: 120\n  template:\n    spec:\n      nodeName: %s\n      restartPolicy: Never\n      containers:\n%s' \
+              "$job" "$node" "$containers_yaml" | kubectl apply -f -
+            # The 5m is spent on ANY non-completion: an unpullable image
+            # (backoffLimit 0 -> Job goes Failed, which `condition=complete`
+            # does not short-circuit on) costs the full timeout too, not only a
+            # wedged node. Bounded either way; best-effort, so we warn and move on.
+            if ! kubectl wait --for=condition=complete "job/${job}" --timeout=300s; then
+              echo "::warning::Pre-pull did not complete on ${node} within 5m -- the node may be unable to pull images or start pods (run 'kubectl describe node ${node}'). Continuing; the rollout may still place pods on a healthy node."
+              kubectl describe "job/${job}" || true
+            fi
+            kubectl delete job "${job}" --ignore-not-found
+            echo "::endgroup::"
+          done
+
       - name: Deploy to Kubernetes cluster
         uses: Azure/k8s-deploy@v5
         with:
@@ -335,9 +414,26 @@ jobs:
           method: kubeconfig
           kubeconfig: ${{ secrets.KUBECONFIG }}
       
+      # A rollout can also fail because of the node a pod lands on, not the
+      # workload itself -- a node that reports Ready while its container runtime
+      # is wedged leaves new pods stuck in ContainerCreating/PodInitializing
+      # with no Warning event (seen 2026-06-06). Dump node health and where the
+      # not-Running pods are scheduled so a bad node is obvious. describe/get
+      # only expose Secret *names*, never values, so this is safe to log.
+      - name: Node health & pod placement
+        run: |
+          echo "--- Nodes ---"
+          kubectl get nodes -o wide || true
+          echo "--- Node conditions & pressure ---"
+          kubectl describe nodes || true
+          echo "--- App pods (with node) ---"
+          kubectl get pods -o wide -l 'app in (nginx,php-mediawiki,php-mediawiki-jobs)' || true
+          echo "--- Pods not Running, all namespaces (with node) ---"
+          kubectl get pods -A -o wide --field-selector=status.phase!=Running || true
+
       - name: Describe Deployments & ReplicaSets
         run: |
-          for app in php-mediawiki php-mediawiki-jobs; do
+          for app in nginx php-mediawiki php-mediawiki-jobs; do
             echo "--- Deployment/$app ---"
             kubectl describe deployment "$app" || echo "Could not describe deployment $app"
             echo "--- ReplicaSets for $app ---"
@@ -356,7 +452,7 @@ jobs:
       - name: Get Pod Names
         id: get-pod-names
         run: |
-          POD_NAMES=$(kubectl get pods -l 'app in (php-mediawiki,php-mediawiki-jobs)' -o jsonpath='{.items[*].metadata.name}')
+          POD_NAMES=$(kubectl get pods -l 'app in (nginx,php-mediawiki,php-mediawiki-jobs)' -o jsonpath='{.items[*].metadata.name}')
           echo "POD_NAMES=$POD_NAMES" >> $GITHUB_OUTPUT
 
       - name: Get Pod Logs

--- a/mediawiki/mw-cronjob.yaml
+++ b/mediawiki/mw-cronjob.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-daily
-              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
+              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.567
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -50,7 +50,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-tridaily
-              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
+              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.567
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -83,7 +83,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-biweekly
-              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
+              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.567
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -124,7 +124,7 @@ spec:
         spec:
           containers:
             - name: cronjob-mw-monthly
-              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
+              image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.567
               envFrom:
                 - secretRef:
                     name: mediawiki-keys

--- a/mediawiki/nginx.yaml
+++ b/mediawiki/nginx.yaml
@@ -38,7 +38,7 @@ spec:
                 path: site.conf
       containers:
         - name: nginx
-          image: ghcr.io/starcitizentools/nginx:26.06.06.566
+          image: ghcr.io/starcitizentools/nginx:26.06.06.567
           # command: [nginx-debug, '-g', 'daemon off;']
           ports:
             - containerPort: 80

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -21,7 +21,7 @@ spec:
         runAsUser: 33
       containers:
         - name: jobrunner
-          image: ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.06.566
+          image: ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.06.567
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]
@@ -43,7 +43,7 @@ spec:
             - secretRef:
                 name: uex-keys
         - name: jobchron
-          image: ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.06.566
+          image: ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.06.567
           command: ["/bin/sh"]
           args:
             ["-c", "/var/www/html/mediawiki-services-jobrunner/entrypoint.sh"]

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -41,7 +41,7 @@ spec:
         # shares anything with the main container -- setupStore just applies any
         # pending SMW store schema changes against the DB.
         - name: smw-setup-store
-          image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
+          image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.567
           command:
             - /bin/sh
             - -c
@@ -55,7 +55,7 @@ spec:
                 name: prd-db-password
       containers:
         - name: php-mediawiki
-          image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
+          image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.567
           ports:
             - containerPort: 9000
           resources:

--- a/shared/backup-cronjob.yaml
+++ b/shared/backup-cronjob.yaml
@@ -172,7 +172,7 @@ spec:
             emptyDir: {}
           containers:
           - name: cronjob-sitemap
-            image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.566
+            image: ghcr.io/starcitizentools/mediawiki:smw-26.06.06.567
             resources:
               limits:
                 memory: "512Mi"


### PR DESCRIPTION
## Why

The [2026-06-06 deploy failure](https://github.com/StarCitizenTools/sct-k8-config/actions/runs/27052565025) was a **node-level wedge**: every new pod (nginx, php-mediawiki, php-mediawiki-jobs) was scheduled onto one node that reported `Ready` but could not start pods — nginx stuck in `ContainerCreating`, the others in `PodInitializing`, with **zero Warning events**. Two gaps in this workflow made that hard to diagnose; this PR closes both, and bundles a routine image bump so merging produces one clean rollout with the hardening active.

## Changes

**1. Failure `debug` job was blind to nginx and to node health.**
- New **Node health & pod placement** step: `kubectl get nodes -o wide`, `describe nodes` (conditions/pressure), app pods `-o wide`, and not-Running pods cluster-wide with their node.
- Added `nginx` to the deployment-describe loop and the pod log/describe selector.

**2. Deployment images weren't pre-pulled.**
- New best-effort **Pre-pull changed Deployment images (all nodes)** step: one `nodeName`-pinned Job per node warms each changed nginx/php-mediawiki/jobs image. A node that can't pull/start surfaces as a **named warning** instead of an opaque rollout timeout. Warns rather than fails (a Deployment surge pod may still land on a healthy node); the StatefulSet pre-pull stays fatal because DB pods are node-pinned. The 5-min per-node wait is paid on any non-completion (failed pull or wedged node), not just a wedge.

**3. Bump Docker images `26.06.06.566` → `26.06.06.567`** (nginx, php-mediawiki, jobs, cronjobs, backup). All three `567` tags verified to exist in GHCR.

## Secret safety
New steps use only `kubectl describe`/`get` (which expose Secret *names*, never values) and emit only image/node names. No `set -x`, no `get secret -o yaml`, no env dumps.

## Validation
- Workflow YAML parses; step order verified. `bash -n` on the new script; rendered pre-pull Job manifest parses as valid YAML (1 and N images). Image-extraction needles verified against the real manifests.
- All edited manifests parse; `.smw.json` cleanup from #24 confirmed intact on this branch (only the explanatory comment remains).

## ⚠️ Deploy prerequisite
Merging triggers a deploy. Node **`lke86850-757936-31c4f0d50000` is currently wedged** (still hanging the prior rollouts as of this writing) — **recycle it first**, or this deploy will hang the same way. The pre-pull step here will at least surface that as a named warning rather than a silent 11-min timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)