### PR TITLE
Cap CPU/memory on maintenance cronjobs to prevent node wedge

### DIFF
--- a/mediawiki/mw-cronjob.yaml
+++ b/mediawiki/mw-cronjob.yaml
@@ -14,6 +14,18 @@ spec:
           containers:
             - name: cronjob-mw-daily
               image: ghcr.io/starcitizentools/mediawiki:smw-26.06.12.579
+              # CPU limit caps the CFS quota so this maintenance job can never
+              # consume a whole node and starve the kubelet (see 2026-06-15 outage:
+              # an unbounded BestEffort biweekly job pinned all 4 cores -> node
+              # Ready=Unknown -> 525s). Low requests keep it schedulable on the
+              # 2-node cluster and make it the first eviction target under pressure.
+              resources:
+                requests:
+                  cpu: "250m"
+                  memory: "512Mi"
+                limits:
+                  cpu: "2"
+                  memory: "4Gi"
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -51,6 +63,13 @@ spec:
           containers:
             - name: cronjob-mw-tridaily
               image: ghcr.io/starcitizentools/mediawiki:smw-26.06.12.579
+              resources:
+                requests:
+                  cpu: "250m"
+                  memory: "512Mi"
+                limits:
+                  cpu: "2"
+                  memory: "4Gi"
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -84,6 +103,18 @@ spec:
           containers:
             - name: cronjob-mw-biweekly
               image: ghcr.io/starcitizentools/mediawiki:smw-26.06.12.579
+              # This job (SemanticMediaWiki:rebuildData over ~282k entities) was the
+              # direct trigger of the 2026-06-15 11:40 UTC outage: BestEffort + no
+              # limit -> ~4 of 4 cores -> kubelet wedged. The cap is the load-bearing
+              # fix. NOTE: the run is also pathologically slow (~7% in 3.5h); the
+              # command itself likely needs revisiting (batch size / shallow update).
+              resources:
+                requests:
+                  cpu: "250m"
+                  memory: "512Mi"
+                limits:
+                  cpu: "2"
+                  memory: "4Gi"
               envFrom:
                 - secretRef:
                     name: mediawiki-keys
@@ -125,6 +156,13 @@ spec:
           containers:
             - name: cronjob-mw-monthly
               image: ghcr.io/starcitizentools/mediawiki:smw-26.06.12.579
+              resources:
+                requests:
+                  cpu: "250m"
+                  memory: "512Mi"
+                limits:
+                  cpu: "2"
+                  memory: "4Gi"
               envFrom:
                 - secretRef:
                     name: mediawiki-keys

--- a/shared/backup-cronjob.yaml
+++ b/shared/backup-cronjob.yaml
@@ -51,6 +51,15 @@ spec:
           containers:
           - name: cronjob-mariadb-backup
             image: d3fk/mysql-s3-backup:stable
+            # Bound the nightly dump so it can't starve a node (mysqldump is mostly
+            # I/O; memory kept generous so a large dump+upload won't OOM the backup).
+            resources:
+              requests:
+                cpu: "100m"
+                memory: "256Mi"
+              limits:
+                cpu: "1"
+                memory: "2Gi"
             args:
             - sh
             - -c


### PR DESCRIPTION
## Why

Root-cause of the **2026-06-15 ~11:40 UTC outage**. `cronjob-mw-biweekly` (`SemanticMediaWiki:rebuildData` over ~282k entities) ran as a **BestEffort pod with no resource limits** and consumed **~4 of the 4-core node's CPU** continuously for hours. That starved the kubelet until it stopped heart­beating → node `Ready=Unknown` at 11:39.

Because that same node also hosted the **single `ingress-nginx` controller** and the **MariaDB primary**, a node-local resource problem became a full outage:
- Cloudflare → origin TLS handshake failed → **error 525**
- PHP lost its DB → `DBConnectionError: Connection refused`

It recurred in waves (12:02 / 12:26 / 12:35 / 12:44) as the job resumed and re-wedged the node.

Evidence (Prometheus): the job pod `cronjob-mw-biweekly-…-vr6g4` held **4.0–4.5 cores** from ≥10:00; wedged-node CPU climbed ~52% → ~93% and `MemAvailable` fell to **1.78%** (~150 MB free, no swap) while the other node stayed flat. `container_oom_events_total` was 0 everywhere — this was CPU starvation, not OOM.

## What

Add explicit `requests` + `limits` to all four `mw` maintenance cronjobs (`daily`, `tridaily`, `biweekly`, `monthly`) and the `mariadb-backup` job:

| Job | cpu req/lim | mem req/lim |
|---|---|---|
| mw-* (4 jobs) | 250m / **2** | 512Mi / 4Gi |
| mariadb-backup | 100m / 1 | 256Mi / 2Gi |

The **CPU limit is the load-bearing fix**: CFS quota caps each job at ≤ half a node, so it can never starve the kubelet **regardless of which of the 2 nodes it lands on** — no anti-affinity or spare node required (the 2-node cluster has none to give). Low requests keep the jobs schedulable and make them the first eviction target under memory pressure, protecting the serving tier. `cronjob-sitemap` already had limits and is unchanged.

## Not in scope (follow-ups)
- **`biweekly` is pathologically slow** (~7% of 282k items in 3.5h) — the `rebuildData` command itself likely needs revisiting (batch size / `--shallow-update` / chunking). The cap stops it taking the site down, but doesn't make it finish.
- **Ingress is a single replica** co-located with the DB — 2+ replicas with anti-affinity would shrink the blast radius of any future node loss.
- **Node-level `kube-reserved`/`system-reserved` CPU** (LKE node-pool config, not in this repo) would protect the kubelet independent of pod limits.

## Validation
YAML parses; all 6 cronjob containers confirmed to carry a `resources` block. No local cluster access — not dry-run-applied against the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)