### PR TITLE
valkey: add redis_exporter sidecar + PodMonitor, fix request/PVC sizing

### DIFF
--- a/mediawiki/valkey.yaml
+++ b/mediawiki/valkey.yaml
@@ -20,7 +20,10 @@ spec:
         - ReadWriteOnce
     resources:
         requests:
-            storage: 1Gi
+            # Linode already rounds this up to its 10.46 GB minimum volume (the
+            # literal 1Gi was misleading vs a 3gb-capped dataset). 10Gi matches
+            # reality; expansion is a no-op/grow on linode-block-storage-retain.
+            storage: 10Gi
     storageClassName: linode-block-storage-retain
 
 ---
@@ -50,7 +53,11 @@ spec:
                         name: valkey
                   resources:
                       requests:
-                          memory: '2Gi'
+                          # Steady-state working set is ~3.1-3.6 GB; the old 2Gi
+                          # request under-counted the pod so the scheduler treated
+                          # it as smaller than reality. (maxmemory/limit retune is
+                          # deferred until the exporter gives hit-rate visibility.)
+                          memory: '3Gi'
                           cpu: '100m'
                       limits:
                           memory: '4Gi'
@@ -60,6 +67,28 @@ spec:
                         mountPath: /data
                       - name: valkey-config-volume
                         mountPath: /usr/local/etc/valkey
+                # redis_exporter sidecar: connects to valkey on localhost:6379 and
+                # exposes INFO stats (used_memory, evicted_keys, keyspace hit/miss,
+                # mem_fragmentation_ratio, rdb_last_bgsave_status) on :9121 for the
+                # PodMonitor below. Read-only; its HTTP server starts even if valkey
+                # is unreachable, so it won't crashloop. docker.io pull is covered by
+                # the default SA's dockerhub-pull imagePullSecret. This adds a 2nd
+                # container, so a bad tag would block pod-Ready -- the deploy's
+                # "Verify image tags exist" guard catches that before rollout.
+                - name: redis-exporter
+                  image: oliver006/redis_exporter:v1.86.0
+                  args:
+                      - '--redis.addr=redis://localhost:6379'
+                  ports:
+                      - containerPort: 9121
+                        name: metrics
+                  resources:
+                      requests:
+                          memory: '24Mi'
+                          cpu: '10m'
+                      limits:
+                          memory: '64Mi'
+                          cpu: '100m'
             volumes:
                 - name: valkey-pv
                   persistentVolumeClaim:
@@ -70,3 +99,24 @@ spec:
                       items:
                           - key: config
                             path: valkey.conf
+
+---
+# Scrape target for the redis_exporter sidecar above. kube-prometheus-stack's
+# operator only selects monitors carrying its release label; this cluster's Helm
+# release is `prometheus-operator` (cf. the `prometheus-operator-kube-p-*` scrape
+# jobs). After deploy, confirm with:  up{namespace="default", pod=~"valkey.*"} == 1
+# If it never appears, the operator's podMonitorSelector uses a different label and
+# the monitoring-stack owner must adjust it (that config lives outside this repo).
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+    name: valkey
+    labels:
+        release: prometheus-operator
+spec:
+    selector:
+        matchLabels:
+            app: valkey
+    podMetricsEndpoints:
+        - port: metrics
+          interval: 30s


### PR DESCRIPTION
## Why
Today's valkey capacity review concluded the cache is **healthy (full-by-design LRU, no OOMKills in 14d)** — but with **no redis/valkey exporter**, the things that actually tell us if it's *filling up badly* are invisible: eviction rate, **cache hit-rate**, `used_memory`, fragmentation, bgsave status. The only signals were cAdvisor `container_memory_*` and logs.

This PR adds that observability and fixes two sizing values. It deliberately **defers** the `maxmemory`-vs-limit retune (the OOM-headroom item) until the exporter is reporting — shrinking the cache blind could trade an OOMKill we've *never hit* for a hit-rate collapse we *can't see*.

## What
- **`redis-exporter` sidecar** (`oliver006/redis_exporter:v1.86.0`) on port `:9121`, connects to `localhost:6379` (no auth configured). Read-only; its HTTP server starts even if valkey is unreachable, so it won't crashloop.
- **`PodMonitor`** labeled `release: prometheus-operator` so the kube-prometheus-stack operator scrapes it — **no monitoring-stack access required** (the CRD ships in this repo and the deploy applies it).
- **`requests.memory` 2Gi → 3Gi** to match the ~3.1–3.6 GB steady-state working set (the scheduler was under-counting the pod, part of what let everything pile onto one node).
- **PVC `storage` 1Gi → 10Gi** to match the volume Linode already provisions (10.46 GB); the `1Gi` line was a misleading trap, not a live risk.

## Once it's scraping, you'll be able to see (and alert on)
hit-rate (`keyspace_hits` / `keyspace_misses`), `evicted_keys` rate (churn/thrash), real `used_memory` vs `used_memory_rss`, `mem_fragmentation_ratio`, `rdb_last_bgsave_status`, rejected writes — i.e. every blind spot from the review.

## Deploy notes / risks
- **One rolling valkey restart** (StatefulSet template change) → cold cache, ~9s RDB reload + brief warmup. **Best merged at low traffic.**
- The **"Verify image tags exist"** deploy guard will reject a bad exporter tag before rollout (covers the "2nd container blocks pod-Ready" risk). `v1.86.0` is the current latest release, so it passes.
- The exporter image isn't in the StatefulSet pre-pull list, so it pulls **inline** during the roll — it's small (~tens of MB) and docker.io is authed via the `dockerhub-pull` secret.
- **Verify after deploy:** `up{namespace="default", pod=~"valkey.*"} == 1`. If it never appears, the operator's `podMonitorSelector` uses a non-default label and the monitoring-stack owner needs to adjust it (that's the one piece outside this repo) — *I'll check this for you once it's live.*

## Deferred to a follow-up (needs exporter data first)
`maxmemory 3gb` sits only ~85% below the `4Gi` OOMKill limit (thin headroom). Once hit-rate is visible we decide: lower `maxmemory` to ~2–2.25gb (free) vs raise `limits.memory` (costs RAM on tight 8 GB nodes). Possibly also `save ""` / `stop-writes-on-bgsave-error no`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)