### PR TITLE
mediawiki: DNS-resolution hardening for app pods (mitigation)

### DIFF
--- a/mediawiki/nginx.yaml
+++ b/mediawiki/nginx.yaml
@@ -29,10 +29,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 33
-      # DNS-resilience hardening (see 2026-06-19 04:40 UTC outage) -- shorten failed
-      # lookups (timeout:2 attempts:2), avoid the glibc dual A/AAAA stall, and reduce
-      # search-domain expansion of external FQDNs (ndots:2). Mitigation, not a cure;
-      # see php-mediawiki.yaml for the full rationale.
+      # DNS-resolution hardening -- see php-mediawiki.yaml / the PR.
       dnsConfig:
         options:
           - name: timeout

--- a/mediawiki/nginx.yaml
+++ b/mediawiki/nginx.yaml
@@ -29,6 +29,19 @@ spec:
     spec:
       securityContext:
         fsGroup: 33
+      # DNS-resilience hardening (see 2026-06-19 04:40 UTC outage) -- shorten failed
+      # lookups (timeout:2 attempts:2), avoid the glibc dual A/AAAA stall, and reduce
+      # search-domain expansion of external FQDNs (ndots:2). Mitigation, not a cure;
+      # see php-mediawiki.yaml for the full rationale.
+      dnsConfig:
+        options:
+          - name: timeout
+            value: "2"
+          - name: attempts
+            value: "2"
+          - name: single-request-reopen
+          - name: ndots
+            value: "2"
       volumes:
         - name: nginx-config-volume
           configMap:

--- a/mediawiki/nginx.yaml
+++ b/mediawiki/nginx.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 33
-      # DNS-resolution hardening -- see php-mediawiki.yaml / the PR.
+      # DNS-resolution hardening -- see php-mediawiki.yaml / PR #32.
       dnsConfig:
         options:
           - name: timeout

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -19,11 +19,7 @@ spec:
       securityContext:
         fsGroup: 33
         runAsUser: 33
-      # DNS-resilience hardening (see 2026-06-19 04:40 UTC outage) -- the jobrunner
-      # was the pod whose logs first showed "getaddrinfo for mariadb-service ...
-      # Temporary failure in name resolution". Shorten failed lookups (timeout:2
-      # attempts:2), avoid the glibc dual A/AAAA stall, reduce search-domain expansion
-      # (ndots:2). Mitigation, not a cure; see php-mediawiki.yaml for full rationale.
+      # DNS-resolution hardening -- see php-mediawiki.yaml / the PR.
       dnsConfig:
         options:
           - name: timeout

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -19,6 +19,20 @@ spec:
       securityContext:
         fsGroup: 33
         runAsUser: 33
+      # DNS-resilience hardening (see 2026-06-19 04:40 UTC outage) -- the jobrunner
+      # was the pod whose logs first showed "getaddrinfo for mariadb-service ...
+      # Temporary failure in name resolution". Shorten failed lookups (timeout:2
+      # attempts:2), avoid the glibc dual A/AAAA stall, reduce search-domain expansion
+      # (ndots:2). Mitigation, not a cure; see php-mediawiki.yaml for full rationale.
+      dnsConfig:
+        options:
+          - name: timeout
+            value: "2"
+          - name: attempts
+            value: "2"
+          - name: single-request-reopen
+          - name: ndots
+            value: "2"
       containers:
         - name: jobrunner
           image: ghcr.io/starcitizentools/mediawiki:smw-jobrunner-26.06.18.583

--- a/mediawiki/php-mediawiki-jobs.yaml
+++ b/mediawiki/php-mediawiki-jobs.yaml
@@ -19,7 +19,7 @@ spec:
       securityContext:
         fsGroup: 33
         runAsUser: 33
-      # DNS-resolution hardening -- see php-mediawiki.yaml / the PR.
+      # DNS-resolution hardening -- see php-mediawiki.yaml / PR #32.
       dnsConfig:
         options:
           - name: timeout

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -30,6 +30,25 @@ spec:
     spec:
       securityContext:
         fsGroup: 33
+      # DNS-resilience hardening (see 2026-06-19 04:40 UTC outage): during a node
+      # network blip, pods on the affected node lost cluster DNS and php-fpm workers
+      # hung on getaddrinfo for mariadb-service, producing mass nginx "upstream timed
+      # out". These resolver options shorten each failed lookup (timeout:2 attempts:2
+      # instead of the 5s x default), avoid the glibc dual A/AAAA stall
+      # (single-request-reopen), and cut wasteful search-domain expansion of external
+      # FQDNs (ndots:2 vs the default 5) -- which also lightens load on the single
+      # CoreDNS replica. This is MITIGATION, not a cure: a full DNS outage still fails.
+      # The real fix (NodeLocal DNSCache w/ serve_stale) needs kubectl access to roll
+      # out/back safely and is deferred.
+      dnsConfig:
+        options:
+          - name: timeout
+            value: "2"
+          - name: attempts
+            value: "2"
+          - name: single-request-reopen
+          - name: ndots
+            value: "2"
       initContainers:
         # SMW schema setup. Lives as an initContainer (not a postStart hook) so
         # its stdout/stderr is captured by the normal log pipeline -- visible in

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -31,7 +31,7 @@ spec:
       securityContext:
         fsGroup: 33
       # DNS-resolution hardening: fail fast on lookup failures and trim CoreDNS
-      # query volume. Mitigation, not a cure -- see the PR for rationale.
+      # query volume. Mitigation, not a cure -- see PR #32 for rationale.
       dnsConfig:
         options:
           - name: timeout

--- a/mediawiki/php-mediawiki.yaml
+++ b/mediawiki/php-mediawiki.yaml
@@ -30,16 +30,8 @@ spec:
     spec:
       securityContext:
         fsGroup: 33
-      # DNS-resilience hardening (see 2026-06-19 04:40 UTC outage): during a node
-      # network blip, pods on the affected node lost cluster DNS and php-fpm workers
-      # hung on getaddrinfo for mariadb-service, producing mass nginx "upstream timed
-      # out". These resolver options shorten each failed lookup (timeout:2 attempts:2
-      # instead of the 5s x default), avoid the glibc dual A/AAAA stall
-      # (single-request-reopen), and cut wasteful search-domain expansion of external
-      # FQDNs (ndots:2 vs the default 5) -- which also lightens load on the single
-      # CoreDNS replica. This is MITIGATION, not a cure: a full DNS outage still fails.
-      # The real fix (NodeLocal DNSCache w/ serve_stale) needs kubectl access to roll
-      # out/back safely and is deferred.
+      # DNS-resolution hardening: fail fast on lookup failures and trim CoreDNS
+      # query volume. Mitigation, not a cure -- see the PR for rationale.
       dnsConfig:
         options:
           - name: timeout


### PR DESCRIPTION
## DNS-resolution hardening for the app tier (mitigation)

**Why.** During the **2026-06-19 ~04:40 UTC** outage, a brief node network blip on the node hosting the app pods knocked out cluster DNS for those pods. php-fpm workers then hung on `getaddrinfo for mariadb-service.default.svc.cluster.local … Temporary failure in name resolution`, requests piled up, and nginx emitted mass `upstream timed out` — a ~5 min partial outage. (The single CoreDNS replica on this 2-node LKE cluster is a standing fragility; a node blip can isolate that node's pods from DNS.)

**What this does.** Adds a `dnsConfig` block to the `php-mediawiki`, `php-mediawiki-jobs`, and `nginx` Deployments:

```yaml
dnsConfig:
  options:
    - { name: timeout, value: "2" }
    - { name: attempts, value: "2" }
    - { name: single-request-reopen }
    - { name: ndots, value: "2" }
```

- `timeout:2 attempts:2` — a failed lookup gives up in ~4s instead of the glibc default (5s × attempts), so php-fpm workers stop wedging for ~30s and the pile-up/recovery is much faster.
- `single-request-reopen` — avoids the glibc dual A/AAAA same-socket stall.
- `ndots:2` (default is 5) — stops wasteful search-domain expansion of external FQDNs (e.g. UEX API), cutting query volume and load on the single CoreDNS replica. Internal short / 1-dot service names keep using search domains, so resolution semantics for `mariadb-service` etc. are unchanged.

**Honest scope — this is mitigation, not a cure.** It shortens the hang and lightens CoreDNS load, but during a *full* DNS-unreachable blip (like 04:40) lookups still fail — it just fails fast and recovers faster instead of wedging workers for 30s. The real fix is **NodeLocal DNSCache** (with `serve_stale`, it would serve the cached `mariadb-service` record straight through such a blip), but that's a DNS-hot-path DaemonSet with no safe rollout/rollback under repo-only (no-kubectl) access, so it's **deferred** until cluster access is available.

**Deploy / blast radius.** Merging to `smw` triggers the CI deploy, which `kubectl apply`s these manifests and **rolling-restarts all three Deployments** (pod-template change). Low risk; fully revertable (edits to existing objects). `ndots:2` is the only behavior-touching change — if reviewers prefer zero semantic change, drop the `ndots` option and keep the rest.

**Related deferred work (needs access this repo doesn't have):** NodeLocal DNSCache, ingress-nginx HA, a 3rd node, and the underlying Linode node instability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
