### PR TITLE
Improve ES diagnostics (pod/volume state) + add gated recover workflow

### DIFF
--- a/.github/workflows/elasticsearch-diagnostics.yml
+++ b/.github/workflows/elasticsearch-diagnostics.yml
@@ -1,22 +1,26 @@
 name: Elasticsearch Diagnostics
 
 # Read-only health check for the single-node Elasticsearch (elasticsearch-es-*)
-# that backs CirrusSearch. Answers "is search broken because an index came back
-# red/unassigned after a node move?" -- the 2026-06-27 reboot relocated the ES
-# StatefulSet pod across nodes, after which full-text search returned
-# `cirrussearch-backend-error` while the stale titlesuggest half-answered.
+# that backs CirrusSearch.
 #
-# Everything here is GET-only against the ES _cluster/_cat APIs (cluster health,
-# indices, aliases, unassigned shards, allocation explain). Nothing is written,
-# deleted, or reindexed -- safe on the live instance. Run it from the Actions
-# tab and read the step output (no artifacts).
+# It has two halves:
+#   1. POD & VOLUME STATE (pure kubectl) -- works even when ES is completely down.
+#      This is the important one when the ES pod is stuck Pending/PodInitializing:
+#      it surfaces the describe/events (FailedMount / Multi-Attach / scheduling),
+#      the PVC/PV, any VolumeAttachment pinning the volume to the wrong node, and
+#      the ECK resource + suspend annotation.
+#   2. ES HTTP HEALTH (_cluster/_cat APIs via a php-mediawiki pod) -- only useful
+#      once ES is actually serving on 9200; degrades gracefully to an
+#      "unreachable" note otherwise.
 #
-# How it reaches ES: ES has TLS disabled and anonymous=superuser
-# (mediawiki/elasticsearch.yaml), and its HTTP service is cluster-internal, so
-# we exec into a running php-mediawiki pod (which can already reach ES for
-# CirrusSearch) and fetch over plain HTTP via the php-curl extension -- the
-# MediaWiki image is guaranteed to have php-curl even though it may lack the
-# curl/wget CLIs.
+# Everything here is GET/describe-only -- nothing is written, deleted, or
+# reindexed. To actually restart a wedged ES pod, use the separate, gated
+# "Elasticsearch Recover" workflow. Run from the Actions tab; read the step output.
+#
+# How the HTTP half reaches ES: ES has TLS disabled and anonymous=superuser
+# (mediawiki/elasticsearch.yaml) and its HTTP service is cluster-internal, so we
+# exec into a running php-mediawiki pod and fetch over plain HTTP via the php-curl
+# extension -- the MediaWiki image has php-curl even though it may lack curl/wget.
 on:
   workflow_dispatch:
 
@@ -30,6 +34,9 @@ concurrency:
 jobs:
   diagnostics:
     runs-on: ubuntu-latest
+    env:
+      ES_POD: elasticsearch-es-elasticsearch-0
+      ES_PVC: elasticsearch-data-elasticsearch-es-elasticsearch-0
     steps:
       - uses: azure/setup-kubectl@v4
 
@@ -40,7 +47,56 @@ jobs:
           method: kubeconfig
           kubeconfig: ${{ secrets.KUBECONFIG }}
 
-      - name: Elasticsearch health
+      - name: "Pod & volume state (works even when ES is down)"
+        run: |
+          set -uo pipefail
+
+          echo "::group::Pod summary (-o wide)"
+          kubectl get pod "$ES_POD" -o wide || echo "(pod not found)"
+          echo "::endgroup::"
+
+          echo "::group::Phase, container readiness & node"
+          kubectl get pod "$ES_POD" -o jsonpath='Phase: {.status.phase}{"\n"}Node:  {.spec.nodeName}{"\n"}' 2>/dev/null || true
+          echo
+          echo "init containers (a stuck first one => the data volume is not mounting):"
+          kubectl get pod "$ES_POD" -o jsonpath='{range .status.initContainerStatuses[*]}  {.name}: ready={.ready} state={.state}{"\n"}{end}' 2>/dev/null || true
+          echo "main containers:"
+          kubectl get pod "$ES_POD" -o jsonpath='{range .status.containerStatuses[*]}  {.name}: ready={.ready} state={.state}{"\n"}{end}' 2>/dev/null || true
+          echo "::endgroup::"
+
+          echo "::group::describe pod (events at the bottom show FailedMount / Multi-Attach / FailedScheduling)"
+          kubectl describe pod "$ES_POD" || echo "(pod not found)"
+          echo "::endgroup::"
+
+          echo "::group::Recent events for the pod"
+          { kubectl get events --field-selector involvedObject.name="$ES_POD" --sort-by=.lastTimestamp 2>/dev/null | tail -40; } || echo "(no events)"
+          echo "::endgroup::"
+
+          echo "::group::PVC / PV"
+          kubectl get pvc "$ES_PVC" -o wide || echo "(pvc not found)"
+          PV=$(kubectl get pvc "$ES_PVC" -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)
+          echo "PV: ${PV:-<none>}"
+          [ -n "${PV:-}" ] && kubectl get pv "$PV" -o wide || true
+          echo "::endgroup::"
+
+          echo "::group::VolumeAttachments (a stale one pinning the ES volume to the old node blocks the mount)"
+          kubectl get volumeattachment -o wide 2>/dev/null || echo "(none / no permission)"
+          if [ -n "${PV:-}" ]; then
+            echo
+            echo "Attachments referencing this ES PV ($PV):"
+            kubectl get volumeattachment -o jsonpath='{range .items[*]}{.metadata.name}{"  pv="}{.spec.source.persistentVolumeName}{"  node="}{.spec.nodeName}{"  attached="}{.status.attached}{"\n"}{end}' 2>/dev/null | grep -F "$PV" || echo "  (none)"
+          fi
+          echo "::endgroup::"
+
+          echo "::group::ECK Elasticsearch resource + suspend annotation"
+          kubectl get elasticsearch elasticsearch -o wide 2>/dev/null || echo "(ECK Elasticsearch resource not found)"
+          echo
+          echo "suspend annotations (if present, ECK is deliberately holding the pod in init):"
+          kubectl get elasticsearch elasticsearch -o jsonpath='{.metadata.annotations}' 2>/dev/null | tr ',' '\n' | grep -i suspend || echo "  (none on ES resource)"
+          kubectl get pod "$ES_POD" -o jsonpath='{.metadata.annotations}' 2>/dev/null | tr ',' '\n' | grep -i suspend || echo "  (none on pod)"
+          echo "::endgroup::"
+
+      - name: Elasticsearch HTTP health (best-effort; skipped gracefully if ES is down)
         run: |
           set -uo pipefail
 
@@ -49,8 +105,8 @@ jobs:
             --field-selector=status.phase=Running \
             -o jsonpath='{.items[0].metadata.name}')
           if [ -z "$POD" ]; then
-            echo "::error::No Running php-mediawiki pod found."
-            exit 1
+            echo "::warning::No Running php-mediawiki pod found; skipping HTTP checks."
+            exit 0
           fi
 
           # --- discover the ES HTTP service (ECK names it <cluster>-es-http) ---
@@ -58,23 +114,22 @@ jobs:
             | grep -E '\-es-http$' | head -1)
           ES_SVC=${ES_SVC:-elasticsearch-es-http}
           ES="http://$ES_SVC:9200"
-
           echo "php pod : $POD"
           echo "ES URL  : $ES"
-          echo "ES pod  : $(kubectl get pods -l elasticsearch.k8s.elastic.co/cluster-name=elasticsearch \
-                              -o jsonpath='{range .items[*]}{.metadata.name}{" on "}{.spec.nodeName}{"\n"}{end}' 2>/dev/null)"
           echo
 
-          # Fetch an ES path from inside the pod via php-curl (no curl/wget CLI needed).
+          # Fetch an ES path from inside the pod via php-curl. NEVER returns non-zero:
+          # on a connection failure it prints an "unreachable" marker so this step
+          # stays green and the pod-state step above remains the source of truth.
           es() {
             kubectl exec "$POD" -c php-mediawiki -- php -r '
               $c = curl_init($argv[1]);
               curl_setopt($c, CURLOPT_RETURNTRANSFER, 1);
               curl_setopt($c, CURLOPT_TIMEOUT, 20);
               $r = curl_exec($c);
-              if ($r === false) { fwrite(STDERR, "curl error: ".curl_error($c)."\n"); exit(1); }
+              if ($r === false) { echo "(ES HTTP unreachable: ".curl_error($c).")\n"; exit(0); }
               echo $r;
-            ' "$ES$1"
+            ' "$ES$1" 2>/dev/null || echo "(kubectl exec failed)"
           }
 
           echo "::group::Cluster health (status = green / yellow / RED)"
@@ -82,12 +137,10 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Indices (sorted by health: red/yellow first)"
-          # columns: health status index uuid pri rep docs.count store.size
           es '/_cat/indices?v&h=health,status,index,pri,rep,docs.count,store.size&s=health:desc,index'
           echo "::endgroup::"
 
           echo "::group::Aliases (which concrete index each CirrusSearch alias points to)"
-          # content / general / titlesuggest are the ones CirrusSearch reads.
           es '/_cat/aliases?v&h=alias,index,is_write_index'
           echo "::endgroup::"
 
@@ -97,17 +150,16 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Allocation explain (why the first unassigned shard is stuck)"
-          # GET with no body explains one unassigned shard; if all are assigned it
-          # returns a harmless "unable to find any unassigned shards to explain".
           es '/_cluster/allocation/explain?pretty'
           echo "::endgroup::"
 
           echo
           echo "Interpretation:"
-          echo "  * status RED + an unassigned PRIMARY on scw_prod_content* / *_general*"
-          echo "    => full-text query path is down (matches cirrussearch-backend-error)."
-          echo "  * titlesuggest present but last built before today => stale suggester"
-          echo "    (autocomplete degraded); today's 07:15 UpdateSuggesterIndex cron failed."
-          echo "  * Fixes, escalating: (1) restart ES so it retries allocation;"
-          echo "    (2) rebuild Cirrus indices: UpdateSearchIndexConfig -> ForceSearchIndex"
-          echo "    (--skipLinks --indexOnSkip, then --skipParse) -> UpdateSuggesterIndex."
+          echo "  * Pod Pending/PodInitializing with the first init container stuck and no"
+          echo "    VolumeAttachment for the ES PV on the pod's node => stuck volume mount;"
+          echo "    fix with the 'Elasticsearch Recover' workflow (delete pod -> re-attach)."
+          echo "  * ES up but status RED with an unassigned PRIMARY on scw_prod_content*/"
+          echo "    *_general* => full-text query path down (cirrussearch-backend-error);"
+          echo "    rebuild: UpdateSearchIndexConfig -> ForceSearchIndex -> UpdateSuggesterIndex."
+          echo "  * ES up, indices green, but autocomplete poor => stale titlesuggest;"
+          echo "    the 07:15 UTC daily cron rebuilds it (or run UpdateSuggesterIndex)."

--- a/.github/workflows/elasticsearch-recover.yml
+++ b/.github/workflows/elasticsearch-recover.yml
@@ -1,0 +1,113 @@
+name: Elasticsearch Recover (restart stuck pod)
+
+# Operator-triggered RECOVERY for the single-node Elasticsearch behind CirrusSearch.
+#
+# Use when the ES pod (elasticsearch-es-elasticsearch-0) is stuck
+# Pending/PodInitializing because its data volume won't mount -- the classic
+# stuck-CSI-attach after an ungraceful node reboot (confirm first with the
+# "Elasticsearch Diagnostics" workflow: first init container stuck + no
+# VolumeAttachment for the ES PV on the pod's node). Deleting the pod makes the
+# StatefulSet/ECK recreate it, which forces the CSI driver to detach and
+# re-attach the volume cleanly.
+#
+# SAFETY:
+#   * Deletes ONLY the ES pod. The data lives on the PVC
+#     (elasticsearch-data-elasticsearch-es-elasticsearch-0), which is NOT touched
+#     -- no data loss. ES is already down when you'd run this, so deleting a
+#     non-serving pod cannot make search worse.
+#   * Gated behind a typed confirmation (confirm=RESTART) so it can't fire by accident.
+#   * The optional VolumeAttachment cleanup only runs if you also tick the box,
+#     and only deletes attachments that reference THIS ES volume.
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type RESTART to confirm deleting the Elasticsearch pod'
+        required: true
+        type: string
+      also_clear_volumeattachment:
+        description: 'Escalation: also delete the stale VolumeAttachment for the ES volume (only if a plain restart did not clear the stuck mount)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: elasticsearch-recover
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    env:
+      ES_POD: elasticsearch-es-elasticsearch-0
+      ES_PVC: elasticsearch-data-elasticsearch-es-elasticsearch-0
+      CONFIRM: ${{ inputs.confirm }}
+    steps:
+      - uses: azure/setup-kubectl@v4
+
+      - name: Kubernetes set context
+        uses: Azure/k8s-set-context@v4
+        with:
+          cluster-type: generic
+          method: kubeconfig
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+
+      - name: Validate confirmation
+        run: |
+          if [ "$CONFIRM" != "RESTART" ]; then
+            echo "::error::Set the 'confirm' input to exactly RESTART to proceed. Got: '$CONFIRM'"
+            exit 1
+          fi
+          echo "Confirmed -- proceeding to restart $ES_POD."
+
+      - name: Before state
+        run: |
+          set -uo pipefail
+          echo "=== ES pod before ==="
+          kubectl get pod "$ES_POD" -o wide || echo "(pod not found)"
+          PV=$(kubectl get pvc "$ES_PVC" -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)
+          echo "PV: ${PV:-<none>}"
+          echo "=== VolumeAttachments referencing the ES PV ==="
+          kubectl get volumeattachment -o jsonpath='{range .items[*]}{.metadata.name}{"  pv="}{.spec.source.persistentVolumeName}{"  node="}{.spec.nodeName}{"  attached="}{.status.attached}{"\n"}{end}' 2>/dev/null \
+            | grep -F "${PV:-NO_PV}" || echo "  (none referencing ${PV:-<none>})"
+
+      - name: Restart Elasticsearch pod (delete -> ECK recreates)
+        run: |
+          set -uo pipefail
+          echo "Deleting pod $ES_POD (the StatefulSet/ECK operator recreates it)..."
+          kubectl delete pod "$ES_POD" --wait=true || echo "(delete returned non-zero; it may already be gone)"
+
+      - name: Clear stale VolumeAttachment (optional escalation)
+        if: ${{ inputs.also_clear_volumeattachment }}
+        run: |
+          set -uo pipefail
+          PV=$(kubectl get pvc "$ES_PVC" -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)
+          if [ -z "${PV:-}" ]; then echo "No PV resolved; skipping."; exit 0; fi
+          VAS=$(kubectl get volumeattachment -o jsonpath="{range .items[?(@.spec.source.persistentVolumeName=='$PV')]}{.metadata.name}{'\n'}{end}" 2>/dev/null || true)
+          if [ -z "${VAS:-}" ]; then echo "No VolumeAttachment references $PV; nothing to clear."; exit 0; fi
+          for va in $VAS; do
+            echo "Deleting stale VolumeAttachment $va (pv=$PV) to force a clean detach/attach..."
+            kubectl delete volumeattachment "$va" --wait=false || echo "(could not delete $va)"
+          done
+
+      - name: After state (wait up to 3 min for ES to become Ready)
+        run: |
+          set -uo pipefail
+          echo "Waiting for the recreated pod to appear..."
+          for i in $(seq 1 18); do
+            kubectl get pod "$ES_POD" >/dev/null 2>&1 && break
+            sleep 5
+          done
+          echo "Waiting for it to become Ready (up to 180s)..."
+          kubectl wait --for=condition=Ready pod/"$ES_POD" --timeout=180s \
+            || echo "(not Ready within 180s -- check the state below and re-run Elasticsearch Diagnostics; if a VolumeAttachment still pins the volume to the old node, re-run this with the escalation box ticked)"
+          echo
+          echo "=== ES pod after ==="
+          kubectl get pod "$ES_POD" -o wide || true
+          echo
+          echo "Next: re-run 'Elasticsearch Diagnostics' to confirm cluster health is green/yellow."
+          echo "If autocomplete is still poor afterwards, titlesuggest is just stale -- the 07:15 UTC"
+          echo "daily cron rebuilds it, or run CirrusSearch:UpdateSuggesterIndex manually."


### PR DESCRIPTION
## What

- **Improves `elasticsearch-diagnostics.yml`** — adds a read-only **Pod & volume state** section (`kubectl describe` / events / PVC / PV / VolumeAttachment / ECK status + suspend annotation) that works *even when ES is completely down*, and makes the ES HTTP checks non-fatal so the job no longer aborts when ES isn't serving on 9200.
- **Adds `elasticsearch-recover.yml`** — a **gated** recovery workflow that restarts the stuck ES pod (`kubectl delete pod` → ECK recreates it) to force a clean CSI volume detach/re-attach, with an optional escalation to delete a stale `VolumeAttachment`.

## Why

Diagnosed today (2026-06-27): the ES pod `elasticsearch-es-elasticsearch-0` has been stuck **Pending / PodInitializing for 8+ hours** — first init container `elastic-internal-init-filesystem` never completes, there are **no kubelet volume stats** for the ES PVC, and ES HTTP **refuses connections** (2 ms, not a timeout). So CirrusSearch returns `cirrussearch-backend-error` and search is down. Node .47 is healthy + schedulable and the PVC is `Bound`, so it's a **stuck CSI volume mount** left over from this morning's ungraceful node reboot — *not* a red index (an earlier inference this corrects).

The original diagnostics workflow only curled ES, which is useless once ES is down (it errored at the first group). This version surfaces the real reason and ships the fix.

## How to use

1. Run **Elasticsearch Diagnostics** → confirm the signature: first init container stuck + no `VolumeAttachment` for the ES PV on the pod's node.
2. Run **Elasticsearch Recover** with `confirm = RESTART` → deletes the pod; ECK recreates it and the volume re-attaches. If still stuck, re-run with `also_clear_volumeattachment` ticked.
3. ES comes up → CirrusSearch recovers → the new Better Stack **Search** monitor / status-page component flips back to green. (If autocomplete is still poor, `titlesuggest` is just stale — the 07:15 UTC daily cron rebuilds it.)

## Safety

Recover deletes **only the ES pod**; data lives on the untouched PVC (`elasticsearch-data-…`), and ES is already down, so it can't make search worse. Gated behind a typed `RESTART` confirmation; the VolumeAttachment cleanup only runs if explicitly ticked and only touches attachments referencing this ES volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
